### PR TITLE
Add doc eval using AWS

### DIFF
--- a/benchmark/general-help/README.md
+++ b/benchmark/general-help/README.md
@@ -103,11 +103,84 @@ Record notes, corrections, and flags in `reviewer_notes.yml` using the question 
 
 ## Step 4: Evaluation
 
-TODO: We plan to have `ipynb` that runs the benchmark against the deployed AWS Bedrock Agent and scores results with an LLM judge 
-(even though questions are currently multiple-choice, the format of evaluation will have the agent provide a free-text answer of merely picking an option).
+`evaluate_bedrock_agent.py` invokes the deployed Bedrock Agent with each benchmark question (one fresh session per question), then uses an LLM judge to score how well the agent's free-text response corresponds to the known correct answer. Although the dataset is multiple-choice, evaluation is done in free-response format to better reflect real-world agent interaction.
 
-Example references:
+### Requirements
 
-- [AWS Bedrock Agent Runtime](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-agent-runtime/client/invoke_agent.html)
+```bash
+pip install boto3 pandas
+```
+
+You also need AWS credentials with access to the Bedrock Agent and Bedrock Runtime (for the judge model). The script creates a `boto3.Session` using the `--profile` flag, which resolves credentials in the standard boto3 order:
+
+1. **Named profile** (`--profile my-profile`) — reads from `~/.aws/credentials` and `~/.aws/config`.
+2. **Environment variables** — if using the default profile, you can set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optionally `AWS_SESSION_TOKEN` for temporary credentials (e.g. from `aws sso login` or `aws sts assume-role`).
+3. **Instance/container role** — if running on EC2, ECS, or Lambda, boto3 picks up the attached IAM role automatically.
+
+### Run
+
+```bash
+cd benchmark/general-help
+python evaluate_bedrock_agent.py
+```
+
+All options have sensible defaults. Override any of them as needed:
+
+```bash
+python evaluate_bedrock_agent.py \
+  --agent-id 2COISTBHRB \              # Bedrock Agent ID
+  --alias-id TSTALIASID \              # Bedrock Agent alias ID
+  --profile default \                  # AWS profile from ~/.aws/credentials
+  --region us-east-1 \                 # AWS region
+  --dataset help_qa_dataset_anthropic.json \  # benchmark dataset
+  --output eval_results.json           # base output path (datestamp appended)
+  # --judge-model can be used to override the LLM judge (defaults to Haiku 4.5)
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--agent-id` | `2COISTBHRB` | Bedrock Agent ID |
+| `--alias-id` | `TSTALIASID` | Bedrock Agent alias ID |
+| `--profile` | `default` | AWS profile from `~/.aws/credentials` |
+| `--region` | `us-east-1` | AWS region |
+| `--dataset` | `help_qa_dataset_anthropic.json` | Path to benchmark dataset JSON |
+| `--judge-model` | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | Bedrock model ID for the LLM judge |
+| `--output` | `eval_results.json` | Base output path (a UTC datestamp is appended automatically) |
+
+### Judge scoring
+
+The LLM judge receives the question, the correct answer, and the agent's response, then assigns a score:
+
+| Score | Meaning |
+|---|---|
+| 2 | Correct — clearly corresponds to the correct answer |
+| 1 | Partially correct or vague |
+| 0 | Incorrect or contradicts the correct answer |
+| -1 | Judge failed to return a valid score |
+
+### Output
+
+Results are saved as `eval_results_<timestamp>.json` (e.g. `eval_results_20260421T153012Z.json`) so that successive runs can be compared for trend tracking. Each file contains:
+
+- `timestamp` — UTC timestamp of the run
+- `config` — agent ID, alias, judge model, and dataset used
+- `results` — per-question scores, agent responses, cited URLs, and attribution hits
+- `errors` — any questions that failed during invocation
+
+### Metrics
+
+The script prints the following metrics to stdout:
+
+| Metric | Description |
+|---|---|
+| Overall accuracy | % of questions scored 2 (correct) by the judge |
+| Score distribution | Count of 0 / 1 / 2 / judge-failed responses |
+| Per-persona accuracy | Accuracy broken down by CONTRIBUTOR, REUSER, FUNDER, PATIENT, X |
+| Cross-page vs single-page accuracy | Accuracy for questions sourced from one page vs. multiple pages |
+| Source attribution rate | % of questions where the agent cited an expected source URL |
+
+### References
+
+- [AWS Bedrock Agent Runtime — `invoke_agent`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-agent-runtime/client/invoke_agent.html)
 - [boto3 Bedrock Agent Runtime client](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-agent-runtime.html)
 - [LLM-as-a-Judge (Zheng et al., 2023)](https://arxiv.org/abs/2306.05685) — methodology for using an LLM to score free-text responses

--- a/benchmark/general-help/evaluate_bedrock_agent.py
+++ b/benchmark/general-help/evaluate_bedrock_agent.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Evaluate AWS Bedrock Agent — NF Portal General Help
+
+Invokes the deployed NF portal chatbot (Bedrock Agent) with each question from
+the help_qa_dataset benchmark, scores responses with an LLM judge, and reports
+accuracy metrics.
+
+Usage:
+    python evaluate_bedrock_agent.py
+    python evaluate_bedrock_agent.py --agent-id ABC123 --alias-id XYZ789
+    python evaluate_bedrock_agent.py --dataset help_qa_dataset_openai.json --profile my-aws-profile
+"""
+
+import argparse
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import boto3
+import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# Agent invocation
+# ---------------------------------------------------------------------------
+
+def invoke_agent(
+    agent_client,
+    agent_id: str,
+    agent_alias_id: str,
+    question: str,
+    session_id: str | None = None,
+) -> tuple[str, list[str]]:
+    """Send a question to the Bedrock agent.
+
+    Returns (response_text, cited_urls) where cited_urls are the web URLs
+    retrieved from the Knowledge Base (web crawler source).
+    """
+    if session_id is None:
+        session_id = str(uuid.uuid4())
+
+    response = agent_client.invoke_agent(
+        agentId=agent_id,
+        agentAliasId=agent_alias_id,
+        sessionId=session_id,
+        inputText=question,
+    )
+
+    completion = ""
+    cited_urls: list[str] = []
+
+    for event in response["completion"]:
+        if "chunk" in event:
+            chunk = event["chunk"]
+            completion += chunk["bytes"].decode("utf-8")
+
+            for citation in chunk.get("attribution", {}).get("citations", []):
+                for ref in citation.get("retrievedReferences", []):
+                    location = ref.get("location", {})
+                    if location.get("type") == "WEB":
+                        url = location.get("webLocation", {}).get("url")
+                        if url and url not in cited_urls:
+                            cited_urls.append(url)
+
+    return completion.strip(), cited_urls
+
+
+# ---------------------------------------------------------------------------
+# LLM judge
+# ---------------------------------------------------------------------------
+
+def judge_response(
+    bedrock_client,
+    judge_model_id: str,
+    question: str,
+    correct_answer: str,
+    agent_response: str,
+) -> int:
+    """Score how well the agent's response matches the correct answer.
+
+    Returns:
+      0 — incorrect or contradicts the correct answer
+      1 — partially correct or vague
+      2 — correct, clearly corresponds to the correct answer
+     -1 — judge failed to return a valid score
+    """
+    prompt = (
+        "You are evaluating an AI assistant's response to a question.\n\n"
+        f"Question: {question}\n\n"
+        f"Correct answer: {correct_answer}\n\n"
+        f"Assistant's response: {agent_response}\n\n"
+        "Score how well the assistant's response corresponds to the correct answer:\n"
+        "  0 — incorrect or contradicts the correct answer\n"
+        "  1 — partially correct or vague\n"
+        "  2 — correct, clearly corresponds to the correct answer\n\n"
+        "Reply with a single digit (0, 1, or 2) and nothing else."
+    )
+
+    body = json.dumps({
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 8,
+        "messages": [{"role": "user", "content": prompt}],
+    })
+    resp = bedrock_client.invoke_model(modelId=judge_model_id, body=body)
+    digit = json.loads(resp["body"].read())["content"][0]["text"].strip()
+
+    return int(digit) if digit in ("0", "1", "2") else -1
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+def score_question(
+    bedrock_client,
+    judge_model_id: str,
+    q: dict,
+    agent_response: str,
+    cited_urls: list[str],
+) -> dict:
+    """Score one question and return a result dict."""
+    choices = q["mc1_targets"]["choices"]
+    labels = q["mc1_targets"]["labels"]
+    correct_answer = choices[labels.index(1)]
+
+    judge_score = judge_response(
+        bedrock_client, judge_model_id, q["question"], correct_answer, agent_response
+    )
+
+    expected_urls = set(q.get("page_urls", []))
+    attribution_hit = bool(expected_urls & set(cited_urls)) if expected_urls else None
+
+    return {
+        "question": q["question"],
+        "persona": q["persona"],
+        "cross_page": len(q.get("page_urls", [])) > 1,
+        "expected_urls": list(expected_urls),
+        "cited_urls": cited_urls,
+        "attribution_hit": attribution_hit,
+        "correct_answer": correct_answer,
+        "judge_score": judge_score,
+        "correct": judge_score == 2,
+        "agent_response": agent_response,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Metrics reporting
+# ---------------------------------------------------------------------------
+
+def print_metrics(results: list[dict]) -> None:
+    """Print evaluation metrics to stdout."""
+    df = pd.DataFrame(results)
+
+    # Overall accuracy
+    overall = df["correct"].mean()
+    print(f"\nOverall accuracy: {overall:.1%}  ({df['correct'].sum()} / {len(df)})")
+
+    # Score distribution
+    score_map = {-1: "judge failed", 0: "incorrect", 1: "partial", 2: "correct"}
+    score_dist = df["judge_score"].value_counts().sort_index()
+    score_dist.index = score_dist.index.map(score_map)
+    print(f"\nScore distribution:\n{score_dist.to_string()}")
+
+    # Per-persona accuracy
+    persona_acc = (
+        df.groupby("persona")["correct"]
+        .agg(accuracy="mean", n="count", correct="sum")
+        .sort_values("accuracy", ascending=False)
+        .reset_index()
+    )
+    persona_acc["accuracy"] = persona_acc["accuracy"].map("{:.1%}".format)
+    print(f"\nPer-persona accuracy:\n{persona_acc.to_string(index=False)}")
+
+    # Cross-page vs single-page
+    cross_acc = (
+        df.groupby("cross_page")["correct"]
+        .agg(accuracy="mean", n="count")
+        .rename(index={True: "cross-page", False: "single-page"})
+        .reset_index()
+        .rename(columns={"cross_page": "type"})
+    )
+    cross_acc["accuracy"] = cross_acc["accuracy"].map("{:.1%}".format)
+    print(f"\nCross-page vs single-page accuracy:\n{cross_acc.to_string(index=False)}")
+
+    # Source attribution
+    attributed = df[df["attribution_hit"].notna()]
+    if len(attributed) > 0:
+        attr_rate = attributed["attribution_hit"].mean()
+        print(
+            f"\nSource attribution rate: {attr_rate:.1%}  "
+            f"({attributed['attribution_hit'].sum():.0f} / {len(attributed)} "
+            f"questions with expected URLs)"
+        )
+    else:
+        print("\nSource attribution: no questions had expected URLs")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def run_evaluation(args: argparse.Namespace) -> None:
+    """Run the full evaluation pipeline."""
+    # AWS clients
+    session = boto3.Session(profile_name=args.profile, region_name=args.region)
+    agent_client = session.client("bedrock-agent-runtime")
+    bedrock_client = session.client("bedrock-runtime")
+
+    # Verify credentials
+    sts = session.client("sts")
+    identity = sts.get_caller_identity()
+    print(f"Authenticated as: {identity['Arn']}")
+    print(f"Region: {args.region}")
+
+    # Load dataset
+    dataset_path = Path(args.dataset)
+    with open(dataset_path) as f:
+        dataset = json.load(f)
+    print(f"Loaded {len(dataset)} questions from {dataset_path.name}")
+
+    # Evaluate
+    results: list[dict] = []
+    errors: list[dict] = []
+
+    for i, q in enumerate(dataset, 1):
+        print(f"  [{i}/{len(dataset)}] {q['question'][:70]}...", flush=True)
+        try:
+            agent_response, cited_urls = invoke_agent(
+                agent_client, args.agent_id, args.alias_id, q["question"]
+            )
+            result = score_question(
+                bedrock_client, args.judge_model, q, agent_response, cited_urls
+            )
+            results.append(result)
+        except Exception as e:
+            errors.append({"question": q["question"], "error": str(e)})
+            print(f"    ERROR: {e}")
+
+    print(f"\nCompleted: {len(results)} scored, {len(errors)} errors")
+
+    # Save results with datestamp
+    output_path = Path(args.output)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    stem = output_path.stem
+    suffix = output_path.suffix
+    dated_path = output_path.with_name(f"{stem}_{timestamp}{suffix}")
+
+    payload = {
+        "timestamp": timestamp,
+        "config": {
+            "agent_id": args.agent_id,
+            "agent_alias_id": args.alias_id,
+            "judge_model": args.judge_model,
+            "dataset": str(dataset_path),
+        },
+        "results": results,
+        "errors": errors,
+    }
+
+    dated_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(dated_path, "w") as f:
+        json.dump(payload, f, indent=2)
+    print(f"Results saved to {dated_path}")
+
+    # Metrics
+    if results:
+        print_metrics(results)
+    else:
+        print("No results to report.")
+
+    if errors:
+        sys.exit(1)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate the NF Portal Bedrock Agent against help_qa_dataset.",
+    )
+    parser.add_argument(
+        "--agent-id",
+        default="2COISTBHRB",
+        help="Bedrock Agent ID (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--alias-id",
+        default="TSTALIASID",
+        help="Bedrock Agent alias ID (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--profile",
+        default="default",
+        help="AWS profile name (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--region",
+        default="us-east-1",
+        help="AWS region (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--dataset",
+        default="help_qa_dataset_anthropic.json",
+        help="Path to benchmark dataset JSON (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--output",
+        default="eval_results.json",
+        help="Output path for results; a datestamp is appended to the filename (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--judge-model",
+        default="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        help="Bedrock model ID for the LLM judge (default: %(default)s)",
+    )
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    run_evaluation(parse_args())


### PR DESCRIPTION
Close #25 for complete coverage of all components (at least individually). Context:
- Docs RAG eval with AWS harness <- this PR
- Graph/Pub RAG eval with astabench 
- Navigation URL construction with curator-benchmarking

This is helpful to review and test since will need to build on this for followup issues #27 and #32 (primarily tagging @changtotheintothemoon who has been involved on this track, @allaway for awareness).  