### PR TITLE
Add meta kb eval

### DIFF
--- a/benchmark/general-help/eval_results_20260422T013729Z.json
+++ b/benchmark/general-help/eval_results_20260422T013729Z.json
@@ -1,0 +1,827 @@
+{
+  "timestamp": "20260422T013729Z",
+  "config": {
+    "agent_id": "2COISTBHRB",
+    "agent_alias_id": "TSTALIASID",
+    "judge_model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "dataset": "help_qa_dataset_anthropic.json"
+  },
+  "results": [
+    {
+      "question": "What is the default license applied to non-human data submitted to the NF Data Portal?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/about-data-licensing"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/about-data-licensing"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "CC0 (No Rights Reserved)",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Based on the NF Data Portal documentation, the default license for non-human data is CC0 (Creative Commons Zero). CC0 is described as a \"no rights reserved\" license by Creative Commons, which essentially places the data in the public domain, making it truly open data available to anyone without restriction. This license is specifically recommended for non-human, raw experimental data, which should be the immediate output of an experiment without analysis or interpretation.\n\nThe CC0 license is chosen as the default because it enables maximum reuse of data, which aligns with the NF Data Portal's goals. It's a respected standard used by many other repositories and allows researchers to reanalyze and repurpose data to advance new discoveries. Additionally, this type of public domain release may be required by funding structures, as it's commonly required for publicly funded projects."
+    },
+    {
+      "question": "What is the maximum file download size supported through the Synapse web interface?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/accessing-data"
+      ],
+      "cited_urls": [],
+      "attribution_hit": false,
+      "correct_answer": "5 GB or 100 files",
+      "judge_score": 0,
+      "correct": false,
+      "agent_response": "I apologize, but I don't have specific information about the maximum file download size supported through the Synapse web interface in my knowledge base. The search didn't return relevant results about file size limitations.\n\nFor accurate information about Synapse file download limits, I recommend:\n\n1. Checking the official Synapse documentation at docs.synapse.org\n2. Contacting Synapse support directly\n3. Looking at the Synapse help center or FAQ section\n\nGenerally, web browsers and web applications may have practical limitations for very large file downloads, and alternative methods like the Synapse Python client or R client are often recommended for downloading large datasets. However, I cannot provide the specific size threshold without access to the current documentation."
+    },
+    {
+      "question": "Which of the following correctly describes the relationship between Synapse and the NF Data Portal?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/how-to-upload-data",
+        "https://help.nf.synapse.org/NFdocs/about"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Synapse is the back-end platform where data is uploaded and stored, while the NF Data Portal is the front-end user interface for exploring that data.",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "The NF Data Portal and Synapse have a complementary backend-frontend relationship. Synapse serves as the data management software and backend platform where all data is actually stored, uploaded, and managed. The NF Data Portal functions as the public-facing frontend that makes this data searchable and accessible to users. When researchers upload data, it goes into Synapse first and then becomes available through the NF Data Portal interface. This architecture allows for collaborative data curation and analysis in Synapse while providing an intuitive exploration and discovery experience through the NF Data Portal."
+    },
+    {
+      "question": "According to the NF Data Portal documentation, what is the typical embargo period provided to data contributors after a grant ends before data must be released?",
+      "persona": "FUNDER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/accessing-data"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/accessing-data",
+        "https://help.nf.synapse.org/NFdocs/frequently-asked-questions"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "12-18 months",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "According to the NF Data Portal documentation, after a grant ends, data contributors are typically provided an embargo period of 12-18 months to publish their results before data must be released. This embargo period varies by funder and is defined in the Data Sharing Plan and/or funder contract.\n\nDuring this embargo period, the data remains private and is only accessible to the research team, NF-OSI data curation/support staff at Sage Bionetworks, and project managers from the funding organization. While the data itself remains private during the embargo, the metadata is publicly visible, allowing portal users to see what type of data is being generated by the project without being able to download or use the actual data files."
+    },
+    {
+      "question": "A researcher wants to share their NF study data publicly. According to the data sharing steps outlined in the documentation, what is the very FIRST step they should take?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about/about-data-sharing"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/about-data-sharing"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Get involved with the NF-OSI community and be accepted as a contributor.",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "According to the NF Data Portal documentation, the very first step a researcher should take when wanting to share their NF study data publicly is to **get involved with the NF-OSI community** by making contact with them at nf-osi@sagebionetworks.org. The documentation specifically states that researchers need to be accepted as a contributor before moving onto the next steps in the data sharing process.\n\nThis initial contact step is crucial because it starts the conversation with the NF-OSI community and ensures that the researcher is properly onboarded as a contributor to the portal before proceeding with the technical aspects of data formatting, organization, upload, and annotation."
+    },
+    {
+      "question": "Why does the NF Data Portal documentation recommend using the CC0 license for non-human research data, and how does this connect to data reuse goals?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": true,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/about-data-licensing",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about/about-data-sharing/10-reasons-to-share-your-data"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/about-data-licensing"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "CC0 places data in the public domain without restrictions, enabling reuse and reanalysis to advance new discoveries, which is the goal of the NF Data Portal-and sharing data publicly can also support new collaborations.",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "The NF Data Portal documentation recommends using the CC0 license for non-human research data because it serves as the equivalent of depositing data in the public domain, making it truly open data available to anyone without restriction. This \"no rights reserved\" license is specifically designed for raw experimental data, which should be the immediate output of an experiment without analysis or interpretation.\n\nThe CC0 recommendation directly supports the NF Data Portal's core data reuse goals in several ways. The documentation explicitly states that \"CC0 is a respected standard in use by many other repositories, it enables reuse, which is the goal of the NF Data Portal.\" The license removes legal barriers that could deter researchers from reanalyzing and repurposing data to advance new discoveries. In the United States specifically, copyright law complexity means that any restrictions, no matter how reasonable, can discourage reuse.\n\nAdditionally, the public domain release through CC0 may be required by funding structures, as this type of release is commonly mandated for publicly funded projects. By removing all copyright restrictions, CC0 allows future researchers to combine datasets, perform meta-analyses, and ask new questions of existing data - all of which align with the portal's mission to maximize the scientific value of neurofibromatosis research data."
+    },
+    {
+      "question": "Which file formats are available for downloading the NF-OSI Data Dictionary for integration into developer tools and workflows?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/annotation-dictionary-browser"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/frequently-asked-questions",
+        "https://help.nf.synapse.org/NFdocs/about"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "JSON-LD, JSON Schema, and LinkML (yaml format)",
+      "judge_score": 0,
+      "correct": false,
+      "agent_response": "The NF-OSI Data Dictionary is available in two file formats for download and integration into developer tools and workflows: CSV and JSON formats. These versioned releases of the core NF-OSI metadata dictionary are hosted on GitHub as an open-source repository.\n\nThe data dictionary includes:\n- The Attribute column listing all NF-OSI terms and concepts (like dataType) and their values (like geneExpression)\n- The Description column providing definitions for each Attribute\n- The Valid Values column listing all allowed terms for concepts in the Attribute column\n\nThis makes it easy for developers to programmatically access and integrate the standardized metadata schema into their applications and analysis workflows."
+    },
+    {
+      "question": "According to the Antibody Epitope Nomenclature guidelines, how should a phospho-specific epitope targeting NF1 at serine position 2515 be correctly formatted?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database/antibody-epitope-nomenclature"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/antibody-epitope-nomenclature"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "phospho-NF1 (Ser2515)",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "According to the Antibody Epitope Nomenclature guidelines in the NF Data Portal documentation, a phospho-specific epitope targeting NF1 at serine position 2515 should be formatted as: **phospho-NF1 (Ser2515)**\n\nThe formatting follows this specific structure:\n- Start with the prefix \"phospho-\" for phospho-specific antibodies\n- Follow with the gene/protein symbol (NF1)  \n- Include the phospho-target in parentheses using the three-character amino acid abbreviation (Ser) followed by the location number (2515)\n\nThis example is actually provided directly in the documentation as one of the valid epitope formats."
+    },
+    {
+      "question": "During the project close-out process on Synapse, who is responsible for confirming that all data listed on the data sharing plan are uploaded?",
+      "persona": "FUNDER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/for-the-funding-organizations/draft-checklist-to-close-a-project"
+      ],
+      "cited_urls": [],
+      "attribution_hit": false,
+      "correct_answer": "Sage Bionetworks",
+      "judge_score": 0,
+      "correct": false,
+      "agent_response": "I apologize, but I was unable to find specific information about the project close-out process and data sharing plan confirmation responsibilities in the available Synapse documentation. The search results did not return sufficient information to answer your question about who is responsible for confirming that all data listed on the data sharing plan are uploaded during the project close-out process.\n\nFor detailed information about Synapse project close-out procedures and data sharing plan requirements, I recommend:\n\n1. Checking the official Synapse documentation directly\n2. Contacting Synapse support for specific procedural questions\n3. Consulting with your institution's research administration or data management team\n4. Reviewing any project-specific agreements or guidelines you may have received\n\nIf you have access to Synapse documentation or project guidelines, those would be the most authoritative sources for this procedural information."
+    },
+    {
+      "question": "What are the three ways listed to contact the NF Data Portal support team for help?",
+      "persona": "X",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contact-us"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/contact-us"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Filing a support ticket, scheduling a Zoom appointment, and emailing nf-osi@sagebionetworks.org",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Based on the NF Data Portal documentation, there are actually four ways to contact the NF Data Portal support team for help. However, if you're specifically looking for three ways, the main contact methods are:\n\n1. Visit their service portal and file a support ticket\n2. Schedule a Zoom appointment with their team\n3. Email them at nf-osi@sagebionetworks.org\n\nThere is also a fourth option: contact them via the \"Need more help?\" button on the lower right hand corner of the documentation pages."
+    },
+    {
+      "question": "According to the Contributing Data overview, which of the following is NOT listed as one of the stages a data contributor must follow when submitting data to the NF Data Portal?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/about-data-sharing"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "How to Publish Data",
+      "judge_score": 1,
+      "correct": false,
+      "agent_response": "According to the Contributing Data overview, there are 6 stages that a data contributor must follow when submitting data to the NF Data Portal:\n\n1. **Become a contributor** - You'll need to be accepted as a contributor before moving onto the next steps\n2. **Prepare data** - Before generating data, review the relevant documentation and ensure you've met the data sharing requirements  \n3. **Deposit data** - This includes uploading and annotating data, as well as providing supplementary information needed to understand and curate the data\n4. **Determine data access controls** - This encompasses data licensing and deciding how the data should be accessed and by whom\n5. **Share data** - After the above steps are complete, you're ready to share your data with others, often after a publication embargo period lifts\n6. **Access data** - Once your data is shared, it becomes accessible to others and meets FAIR data standards (findable, accessible, interoperable, and reusable)\n\nWithout seeing the specific answer choices you're referring to, I cannot identify which option is NOT listed as one of these stages. If you could provide the answer choices, I would be happy to help identify which one is not part of the official 6-stage process outlined in the Contributing Data overview."
+    },
+    {
+      "question": "When closing a project, what action must Sage take regarding a DOI for the project/dataset, and why is it important for contributors to include it in their manuscripts?",
+      "persona": "FUNDER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/for-the-funding-organizations/draft-checklist-to-close-a-project"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/draft-checklist-to-close-a-project"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Sage checks whether a DOI has been minted and, if not, asks the contributor to create one and include it in the manuscript's Data Availability Statement so readers can find the data.",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "When closing a project, Sage must check that a DOI (Digital Object Identifier) has been minted for the project/dataset. If no DOI has been created yet, Sage must ask the data contributor or coordinator to create one.\n\nIt's important for contributors to include the DOI in their manuscripts because it creates a direct link between the published research and the underlying dataset. Specifically, contributors should include the DOI in their manuscript's Data Availability Statement so that readers can easily find and access the data that supports the published findings. This ensures proper attribution of the dataset and enables reproducibility and further research by allowing others to locate the exact data used in the study."
+    },
+    {
+      "question": "During the Initial Award Phase, what is a consequence of NOT completing the Data Sharing Plan (DSP)?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/data-contributor-checklist"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/data-contributor-checklist"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "It can lead to delays in funding disbursements.",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "During the Initial Award Phase, not completing the Data Sharing Plan (DSP) can lead to delays in funding disbursements. The DSP is a critical requirement that must be completed in a timely manner as part of the initial award process. The funding agency and Sage Bionetworks work with researchers during this phase to complete the data sharing plan and set up the Synapse project workspace, and failure to complete this requirement can impact the release of funding."
+    },
+    {
+      "question": "Which of the following sequencing assays does NF-OSI support for Copy Number Variation (CNV) processing?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/data-processing/eligible-datatypes-and-workflows"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/eligible-datatypes-and-workflows"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Whole Genome Sequencing (WGS) only",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Based on the NF-OSI documentation, for Copy Number Variation (CNV) processing, NF-OSI supports:\n\n**Whole Genome Sequencing (WGS)** - CNV processing is available and supported for WGS data.\n\n**Whole Exome Sequencing (WES)** - CNV processing is technically available for WES data, but NF-OSI has decided not to provide this processing. This decision follows recommendations from scientists and engineers at Sage Bionetworks who have identified various problems in interpretation of processed CNV data from WES workflows during downstream analysis.\n\nSo to directly answer your question: NF-OSI supports CNV processing for **WGS only**, while WES is not supported for CNV processing due to analytical limitations."
+    },
+    {
+      "question": "How frequently is the data in the ProjectLIVE app updated to reflect changes in Synapse studies?",
+      "persona": "FUNDER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/for-the-funding-organizations/how-to-use-projectlive/faqs"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/for-the-funding-organizations",
+        "https://help.nf.synapse.org/NFdocs/how-to-use-projectlive"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Daily",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Based on the documentation available, the ProjectLIVE app provides daily tracking of data file uploads and annotations from Synapse studies. The app includes daily tracking of the upload and annotation of data files generated in funded studies, which suggests that the data is updated on a daily basis to reflect changes in Synapse studies.\n\nHowever, the specific technical details about the exact refresh schedule or synchronization frequency are not explicitly detailed in the available documentation. The app's \"New Submissions\" module allows users to view files uploaded within customizable time windows (with a default of 60 days), indicating that the system is designed to capture and display recent changes promptly.\n\nFor more specific technical details about the exact update frequency or synchronization schedule, you may need to contact the Sage Bionetworks team directly through the NF Data Portal support channels."
+    },
+    {
+      "question": "In the NF Research Tools Central data model, where is the schema maintained in machine-readable format?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database/data-model-schema"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/data-model-schema"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "As JSON-LD files on GitHub",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "In the NF Research Tools Central data model, the schema is maintained in machine-readable format as JSON-LD files. These files are available on GitHub at the nf-research-tools-schema repository (https://github.com/nf-osi/nf-research-tools-schema). Changes to the schema are tracked through release notes, ensuring transparency and version control for the data model updates."
+    },
+    {
+      "question": "According to the Data Contributor Checklist, who must give approval before data can be made public on the NF Data Portal?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/data-contributor-checklist"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/data-contributor-checklist"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "The principal investigator of the study",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "According to the Data Contributor Checklist, the Principal Investigator (PI) must give approval before data can be made public on the NF Data Portal. Specifically, during the Data Publication Prep Phase, the documentation states that \"We always require the approval of the principal investigator before making data public.\" The process involves the Sage team reaching out to the PI via email to request approval, and the PI must provide their approval by responding to that email from the Sage team before the data is made accessible to the public."
+    },
+    {
+      "question": "The NF-OSI data processing pilot initiative covers NTAP-funded projects from which time range, and what kind of data does it aim to uniformly process?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": true,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/data-processing/eligible-datatypes-and-workflows",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/data-processing"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/data-processing",
+        "https://help.nf.synapse.org/NFdocs/eligible-datatypes-and-workflows",
+        "https://help.nf.synapse.org/NFdocs/nextflow-data-processing-configuration"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "NTAP-funded projects from 2018-2024, focusing on genomic and transcriptomic data",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "The NF-OSI data processing pilot initiative covers NTAP-funded projects from the time range of 2018 to 2024. This initiative aims to uniformly process genomic and transcriptomic data using standardized data processing pipelines. The specific types of data it processes include:\n\n1. **Genomic data**: Whole Exome Sequencing (WES) and Whole Genome Sequencing (WGS) data, with processing for germline and somatic SNVs/INDELs, copy number variations, structural variants, and microsatellite instability.\n\n2. **Transcriptomic data**: Both bulk RNA sequencing and single-cell RNA sequencing data, processed to generate raw gene expression counts.\n\nThe goal is to ensure uniformity in data processing so that the processed data can be shared on the NF Data Portal and facilitate utilization in other data analysis and exploration platforms."
+    },
+    {
+      "question": "What is the primary purpose of the ProjectLIVE app for funding organizations?",
+      "persona": "FUNDER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/for-the-funding-organizations"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/for-the-funding-organizations",
+        "https://help.nf.synapse.org/NFdocs/how-to-use-projectlive"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "To consolidate high-level information about individual studies and provide daily tracking of data file uploads and annotations",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "The primary purpose of the ProjectLIVE app for funding organizations is to provide comprehensive tracking and oversight of their funded research portfolio. The app serves as a centralized dashboard that consolidates high-level information about individual studies funded through various initiatives, allowing funding organizations to monitor the impact and progress of their investments in research.\n\nProjectLIVE helps funding organizations track their funding portfolio at various levels of granularity through four key modules: Snapshot (providing a bird's eye view of funding structure and activity year over year), Publications (longitudinal tracking of associated publications), Participating Studies (detailed information about individual studies including file annotation status and milestone tracking), and New Submissions (visualization of newly uploaded files within specified time windows).\n\nThe app enables funding organizations to see summary-level information about data generation, file uploads, annotation progress, and research outputs, making it an effective tool for understanding the tangible impact their organization has made in supporting neurofibromatosis research."
+    },
+    {
+      "question": "During a study's embargo period, which of the following parties can access the actual data files (not just metadata)?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/frequently-asked-questions"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/frequently-asked-questions"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Only the research team, NF-OSI data curation and support staff at Sage Bionetworks, and designated project managers from the funding organization",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "During a study's embargo period, access to the actual data files (not just metadata) is restricted to a limited set of parties. Based on the NF Data Portal documentation, the following parties can access the actual data files during the embargo period:\n\n1. **The research team** - Members of the original research group conducting the study\n2. **NF-OSI data curation/support staff at Sage Bionetworks** - Technical staff responsible for data management and curation\n3. **Project manager(s) from the funder** - Representatives from the funding organization overseeing the project\n\nIt's important to note that during the embargo period, all data has publicly-visible metadata (so others can see what type of data is being generated), but the actual data files remain private and cannot be downloaded by the general public or other researchers outside these authorized parties."
+    },
+    {
+      "question": "What does a researcher need to do before they can download data from the NF Data Portal?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/getting-started"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/getting-started"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Register for a Synapse account and agree to the Synapse Terms and Conditions of Use",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Before downloading data from the NF Data Portal, researchers need to take the following steps:\n\n1. **Register for a Synapse Account**: All data downloads require registration for a Synapse account at synapse.org. During registration, you must agree to the Synapse Terms and Conditions of Use.\n\n2. **For Open Access Data**: Once you have a registered Synapse account, you can download publicly available data immediately.\n\n3. **For Controlled Access Data**: Some datasets require additional approval. You must request access by reading and electronically agreeing to data-specific terms and conditions for each controlled access dataset you want to download.\n\n4. **Acknowledge Data Use**: When using any downloaded data in publications (whether open or controlled access), you're required to include specific acknowledgement statements, which can be found on each study's details page.\n\nThe portal operates on open science principles, so anyone can browse and explore the content without any account setup. However, actual data downloading always requires at minimum a registered Synapse account."
+    },
+    {
+      "question": "According to the NF Data Portal Glossary, what distinguishes a 'Study' from a 'Dataset'?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/glossary"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/glossary"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "A study is the primary unit of data organization representing a research project, while a dataset bundles multiple similar data files into one large bulk file",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "According to the NF Data Portal Glossary, there is a clear distinction between a Study and a Dataset:\n\nA **Study** is defined as \"the primary unit of data organization in the portal\" that \"represents an individual research project with specific objectives and focus.\" Studies are comprehensive containers that bundle multiple pieces of project information together, including study title, summary, lead investigator, access requirements, acknowledgement statements, data files, datasets, metadata files, tools, publications, and related studies. Studies are typically associated with a grant and often represent data generated from a specific human cohort, experiments on a model system, cross-consortium data processing efforts, or data associated with a specific publication.\n\nA **Dataset**, on the other hand, is more focused on the data itself. Datasets \"bundle multiple similar data files together into one large bulk file that can be downloaded at once.\" They range in size from hundreds of files to just a few, and sometimes have been processed or harmonized to improve their usefulness.\n\nIn essence, a Study is the broader organizational unit encompassing an entire research project with all its components, while a Dataset is a specific collection of related data files within that study that can be downloaded as a unit."
+    },
+    {
+      "question": "Under the Controlled Access governance model on the NF Data Portal, how long does a data access approval last before it must be renewed?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/governance-models"
+      ],
+      "cited_urls": [],
+      "attribution_hit": false,
+      "correct_answer": "1 year",
+      "judge_score": 0,
+      "correct": false,
+      "agent_response": "Based on my search through the NF Data Portal documentation, I was unable to find specific information about the duration of controlled access data approvals or renewal requirements for the NF Data Portal's Controlled Access governance model.\n\nThe documentation confirms that some data on the NF Data Portal is classified as \"controlled access\" and requires users to request access by reading and electronically agreeing to data-specific terms. However, the available documentation does not specify:\n\n- How long a controlled access approval lasts\n- When renewals are required\n- The specific renewal process or timeline\n\nFor this specific information about controlled access approval duration and renewal requirements, I recommend contacting the NF Data Portal support team directly at nf-osi@sagebionetworks.org, as they would have the most current and detailed information about their data governance policies and access management procedures."
+    },
+    {
+      "question": "A researcher wants to cite data they used from the NF Data Portal in a publication. Which of the following does the documentation recommend including?",
+      "persona": "REUSER",
+      "cross_page": true,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/getting-started",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/frequently-asked-questions"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/frequently-asked-questions"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "The acknowledgement statement from the Study Details page, the Synapse ID or DOI, and a standard NF Data Portal acknowledgement statement",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "According to the NF Data Portal documentation, when citing data used from the portal in a publication, researchers should include several key elements:\n\n1. **Citation/acknowledgement information from the Study page** - Use the specific citation information provided on the Study page for the data you are using, including any \"Acknowledgement Statements\" section.\n\n2. **Synapse ID or DOI** - Reference the persistent Synapse ID (e.g., syn2343195) or DOI when available (e.g., 10.7303/syn2343195) for the specific data or study. These are persistent accession numbers that help others locate the exact data used.\n\n3. **NF Data Portal acknowledgement statement** - Include the following standardized acknowledgement: \"The results published here are in whole or in part based on data obtained from the NF Data Portal (http://www.nf.synapse.org) and made available through the NF Open Science Initiative.\"\n\n4. **Portal location reference** - Mention that the data is available on the NF Data Portal at nf.synapse.org and on Synapse with the specific URL.\n\nThe documentation emphasizes that including the standardized acknowledgement statement helps the portal team track publications and measure the impact of the portal on the research community. Both DOIs and Synapse IDs can be found on the portal Study page and serve as reliable, persistent identifiers for referencing specific datasets."
+    },
+    {
+      "question": "When annotating data using the NF Data Curator App, what should you do if your manifest required custom terms not found in the existing dictionary?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-annotate-data"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/how-to-annotate-data",
+        "https://help.nf.synapse.org/NFdocs/about"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Email the completed Google Sheet or Excel file to nf-osi@sagebionetworks.org so new terms can be added to the dictionary.",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "When annotating data using the NF Data Curator App, if your manifest requires custom terms that are not found in the existing NF-OSI dictionary, you should NOT submit the manifest directly through the app. Instead, you need to email the completed Google Sheet or Excel file to nf-osi@sagebionetworks.org so that the NF-OSI team can add your new terms to their dictionary. The team will work with you to get the annotations properly applied to your data once the custom terms have been incorporated into the dictionary.\n\nThis process ensures that the controlled vocabulary and data standards are maintained across the NF Data Portal, which is essential for enabling data discovery and ensuring consistency in terminology. The NF-OSI uses controlled vocabularies to allow users to find what they're looking for on the portal without having to search through multiple terms for the same concept."
+    },
+    {
+      "question": "According to the NF Data Portal's data formatting guidelines, which level of RNA-seq data is considered 'raw'?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-format-your-data"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/how-to-format-your-data"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "FASTQ or unaligned BAM/CRAM files",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "According to the NF Data Portal's data formatting guidelines, for RNA-seq data the \"raw\" level corresponds to FASTQ files, unaligned BAM files, or CRAM files. The guidelines specify that for bulk RNA sequencing, either \"raw OR semi-processed AND processed\" data is required, where raw data includes FASTQ, unaligned BAM, or CRAM formats, while semi-processed data would be aligned BAM files, and processed data would be counts matrices or quantification files (like quant.sf files generated by Salmon-based RNA-seq workflows).\n\nThe guidelines also reference that their level nomenclature can be cross-referenced with the TCGA data levels system, where 'raw' corresponds to Level 1 data."
+    },
+    {
+      "question": "What is the correct folder structure for raw data files in a Synapse project on the NF Data Portal?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-organize-data"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/how-to-organize-data"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Files should be placed inside a dataset subfolder under 'Raw Data', not directly under 'Raw Data' itself.",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Based on the NF Data Portal documentation, there is a specific folder structure required for organizing raw data files in a Synapse project. The top-level structure should include these main folders:\n\n**Main Project Structure:**\n- **Raw Data** or **Data** (the primary folder for all datasets)\n- **Milestone Reports** or **Reporting** (for summary reports and milestones)\n- **Data Sharing Plan** (for versioned copies of your data sharing plan)  \n- **Analysis** (for protocols, code, and derived results)\n\n**Raw Data Folder Organization:**\nWithin the Raw Data/Data folder, you must create subfolders organized by data type or dataset. Files should never be placed directly in the Raw Data folder - they must be in subfolders. Each dataset subfolder should contain:\n- The actual data files\n- A manifest.csv file for metadata\n\n**Example Structure:**\n```\nRaw Data\n\u251c\u2500\u2500 Imaging\n\u2502   \u251c\u2500\u2500 img1.tiff\n\u2502   \u251c\u2500\u2500 img2.tiff\n\u2502   \u2514\u2500\u2500 manifest.csv\n\u251c\u2500\u2500 Cognitive Assessments\n\u2502   \u251c\u2500\u2500 a_visit.xlsx\n\u2502   \u251c\u2500\u2500 b_visit.xlsx\n\u2502   \u2514\u2500\u2500 manifest.csv\n\u2514\u2500\u2500 RNA-seq\n    \u251c\u2500\u2500 abc.fq.gz\n    \u251c\u2500\u2500 def.fq.gz\n    \u2514\u2500\u2500 manifest.csv\n```\n\nDataset folders are automatically tagged with `contentType=dataset` when created properly. This structure is required for the data to be detected by the NF Data Portal's curation application and ensures proper data discovery and management."
+    },
+    {
+      "question": "Which of the following types of research tools is NOT listed as currently accepted for submission to NF Research Tools Central?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database/how-to-contribute-a-tool"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/neurofibromatosis-research-tools-database",
+        "https://help.nf.synapse.org/NFdocs/how-to-contribute-a-tool"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Clinical trial protocols",
+      "judge_score": 1,
+      "correct": false,
+      "agent_response": "Based on the NF Research Tools Central documentation, the currently accepted types of research tools for submission are:\n\n1. **Cell lines** - immortalized cell lines or primary cell cultures that exist in a large enough quantity to be shared\n2. **Animal models** - genetically modified models of any species as well as well-characterized and shareable xenograft models  \n3. **Antibodies** - any commercially available or self-distributed antibody for NF-relevant targets\n4. **Genetic reagents** - plasmids, guide RNAs, useful primers, or other genetic tools for studying NF\n5. **Biobanks** - tissue or other biospecimen repositories with NF tumors or other NF-relevant biospecimens\n\nHowever, I notice you're asking about which type is NOT accepted, but you haven't provided me with a list of options to choose from. Could you please provide the specific types you'd like me to evaluate against this accepted list?"
+    },
+    {
+      "question": "A researcher wants to reuse single-cell RNA sequencing data from the NF Data Portal. According to the data formatting guidelines, what processed file format is required for single-cell/single-nucleus RNA-seq data?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-format-your-data"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/how-to-format-your-data"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "TSV (processed expression matrix) and hda5/hdf5 format following the cellxgene required format",
+      "judge_score": 1,
+      "correct": false,
+      "agent_response": "According to the NF Data Portal's data formatting guidelines, for single-cell RNA sequencing data, researchers must provide data in both raw and processed formats. Specifically, the processed file format required is **hda5/hdf5 format following the cellxgene required format**.\n\nThe guidelines specify that single-cell RNA sequencing data requires:\n- **Raw data**: FASTQ files (which should be created from bcl files with a program like `cellranger mkfastq`)\n- **Processed data**: hda5/hdf5 format following cellxgene required format\n\nThe hda5 format is a type of hdf5 file, and the documentation notes that more information on formatting hda5 files can be found in their additional documentation resources."
+    },
+    {
+      "question": "Which types of observations are explicitly stated as NOT acceptable when contributing to the NF Research Tools Central observation database?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database/how-to-contribute-an-observation"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/how-to-contribute-an-observation"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Observations that are crude, derogatory, or disparaging",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Based on the NF Data Portal documentation, observations that are explicitly NOT acceptable when contributing to the NF Research Tools Central observation database are those that are crude, derogatory, or disparaging. The documentation specifically states that while acceptable observations include general comments and reviews, usage instructions, depositor comments, issues, and scientific observations noted from use, \"Observations that are crude, derogatory, or disparaging will not be accepted.\""
+    },
+    {
+      "question": "What is the correct order of steps to begin sharing data on the NF Data Portal?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-share-data-an-overview"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/how-to-upload-data",
+        "https://help.nf.synapse.org/NFdocs/how-to-share-data-an-overview",
+        "https://help.nf.synapse.org/NFdocs/data-contributor-checklist",
+        "https://help.nf.synapse.org/NFdocs/contributing-data"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Register on Synapse and get certified -> Complete a data sharing plan -> Upload data -> Annotate data",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "To begin sharing data on the NF Data Portal, you need to follow these steps in the correct order:\n\n1. **Become a Registered and Certified User**: Start by registering on Synapse.org and complete the certification quiz. Certification is required to upload data. You can also add your ORCID credentials to your profile during this step.\n\n2. **Complete your Data Sharing Plan (DSP)**: If you're funded by partners like NTAP, GFF, or CTF, you'll receive a pre-filled data sharing plan that you need to review and complete with details about your anticipated data types, sample numbers, upload dates, access requirements, and whether you're submitting human data.\n\n3. **Format your data**: Prepare your data according to the portal's formatting requirements.\n\n4. **Organize your data**: Structure your data appropriately for upload.\n\n5. **Upload your data**: Use Synapse tools to upload your data to the correct location.\n\n6. **Annotate your data**: Label your files with metadata so users can easily find and filter the data they need when exploring the portal.\n\n7. **Review your project**: Once your data is ready for public release, review everything to ensure you have proper permissions, correct annotations, and all associated details are accurate.\n\nThe NF Data Portal uses Synapse.org as the backend data management system, while the portal itself serves as the front-end interface for accessing the data."
+    },
+    {
+      "question": "What does the Synapse certification quiz consist of, and approximately how long does it take?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-share-data-an-overview"
+      ],
+      "cited_urls": [],
+      "attribution_hit": false,
+      "correct_answer": "15 questions covering the Synapse Commons Data Use Procedure, typically taking 15-20 minutes",
+      "judge_score": 0,
+      "correct": false,
+      "agent_response": "I searched for information about the Synapse certification quiz in the available documentation, but unfortunately I wasn't able to find specific details about what the quiz consists of or how long it takes to complete. The search results didn't contain sufficient information about the certification quiz structure, content, or duration.\n\nTo get accurate information about the Synapse certification quiz requirements, I'd recommend:\n- Checking the official Synapse documentation directly at docs.synapse.org\n- Looking for certification information in your Synapse account settings\n- Contacting Synapse support for specific details about the certification process\n\nI apologize that I couldn't provide the specific details you were looking for about the certification quiz content and timing."
+    },
+    {
+      "question": "When manually creating a folder in Synapse for data upload, what annotation must be added to make the folder appear in the Data Curator App?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-upload-data"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/how-to-upload-data"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "contentType = dataset",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "When manually creating a folder in Synapse for data upload, you must add the annotation `contentType = dataset` to make the folder appear in the Data Curator App. This annotation can be added manually by clicking the annotation folder icon and adding the Key \"contentType\" with the value \"dataset\". Folders created automatically by Sage will have this annotation applied by default, but manually created folders require you to add this annotation yourself."
+    },
+    {
+      "question": "Which ProjectLIVE module allows a funder to see a list of all newly uploaded files within a customizable recent time window?",
+      "persona": "FUNDER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/for-the-funding-organizations/how-to-use-projectlive"
+      ],
+      "cited_urls": [],
+      "attribution_hit": false,
+      "correct_answer": "New Submissions",
+      "judge_score": 0,
+      "correct": false,
+      "agent_response": "Sorry I cannot answer"
+    },
+    {
+      "question": "As a researcher reusing NF Data Portal data, where would you find extensive individual-level clinical data such as patient demographics and phenotypes?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/accessing-data/metadata"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/about",
+        "https://help.nf.synapse.org/NFdocs/accessing-data",
+        "https://s3.amazonaws.com/static.synapse.org/governance/SageBionetworksSynapseTermsandConditionsofUse.pdf?v=5",
+        "https://help.nf.synapse.org/NFdocs/resource-hub"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "If available, as a .csv file or Synapse table in the project, though these are usually harder for contributors to share in full detail and often have more restrictions",
+      "judge_score": 1,
+      "correct": false,
+      "agent_response": "For extensive individual-level clinical data such as patient demographics and phenotypes, you would primarily find this information in **controlled access datasets** on the NF Data Portal. This type of sensitive clinical information is typically not available through open access due to privacy regulations and informed consent requirements.\n\nThe NF Data Portal operates on a tiered data access system where clinical data containing patient demographics, detailed phenotypic information, and other sensitive details are classified as \"Controlled Data.\" This data requires additional approvals and agreements to access because it carries some risk of re-identification and could potentially harm human participants if misused.\n\nTo access individual-level clinical data, researchers need to:\n1. Have a certified Synapse account\n2. Apply for controlled access permissions\n3. Agree to additional data-specific terms of use\n4. Sometimes undergo independent review by an ethics committee or Institutional Review Board\n\nThe portal provides step-by-step guides for downloading controlled access data, and you can explore available datasets by filtering for \"controlled access\" in the datasets section to identify which studies contain the clinical information you're looking for."
+    },
+    {
+      "question": "A contributor wants to update a tool they previously submitted to the NF Research Tools Central. They also want to upload a corrected dataset to Synapse. Which contact channel or mechanism is correct for each action?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": true,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-upload-data",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database/how-to-update-a-contribution"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/how-to-update-a-contribution"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Tool updates go through the Sage Bionetworks help portal (selecting 'NF Research Tools Central' -> 'Update a Research Tool or Observation'), while dataset uploads are done directly in Synapse",
+      "judge_score": 1,
+      "correct": false,
+      "agent_response": "For updating a tool in the NF Research Tools Central, there is a specific process through their help portal. Contributors should navigate to the NF Research Tools Central help portal, click \"NF Research Tools Central\", then click \"Update a Research Tool or Observation,\" and complete the prompts. They need to provide the name or Resource_id of the tool to be updated, a short description of the update requested, and the timeline. Alternatively, they can contact nf-osi@sagebionetworks.org directly for assistance.\n\nFor uploading a corrected dataset to Synapse, the search results from the Synapse documentation did not return specific information about the contact mechanism or process for updating existing datasets. Based on the available information, the best approach would be to contact the general Synapse support channels or the NF Data Portal team at nf-osi@sagebionetworks.org, as they handle NF-related data submissions and can provide guidance on the proper procedure for dataset corrections and uploads to Synapse."
+    },
+    {
+      "question": "When opening a new project on the NF Data Portal, at what step does the study become active and visible on the portal?",
+      "persona": "FUNDER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/for-the-funding-organizations/opening-a-new-project"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/opening-a-new-project"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "When Sage adds the 'provision' tag to the DSP GitHub pull request, triggering the Synapse Study Creation process",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Based on the NF Data Portal documentation, a study becomes active and visible on the portal at a specific point in the project setup process. When SAGE adds a \"provision\" tag to the Data Sharing Plan (DSP) GitHub pull request, this triggers the Synapse Study Creation process. At this exact moment, the study becomes active and visible on the NF Data Portal.\n\nThis occurs after the data sharing plan has been completed and reviewed, but before data upload begins. Once the study is provisioned and visible, SAGE sends an email to the Principal Investigator with links to the Synapse project space, the Study page in the NF Data Portal, the final DSP, and documentation resources."
+    },
+    {
+      "question": "A researcher wants to find processed and harmonized RNA-seq datasets aggregated from public repositories to compare with NF data. Which publicly available resource is best suited for this need?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about/about-data-sharing/other-publicly-available-data-resources"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/how-to-format-your-data",
+        "https://help.nf.synapse.org/NFdocs/data-processing",
+        "https://help.nf.synapse.org/NFdocs/portal-structure"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "refine.bio",
+      "judge_score": 1,
+      "correct": false,
+      "agent_response": "Based on your need for processed and harmonized RNA-seq datasets from public repositories to compare with NF data, here are the best publicly available resources:\n\n**Top Recommendations:**\n\n1. **TCGA (The Cancer Genome Atlas) via GDC Data Portal** - Offers harmonized RNA-seq data processed through standardized pipelines, making it ideal for cross-study comparisons. The data has been reprocessed using consistent methods and reference genomes.\n\n2. **GTEx (Genotype-Tissue Expression)** - Provides processed RNA-seq data from normal tissues across the human body, excellent for comparing with NF tissue data to understand disease-specific expression patterns.\n\n3. **UCSC Xena** - Aggregates and harmonizes datasets from multiple sources including TCGA, GTEx, and other public repositories. It provides uniformly processed data that's ready for comparative analysis.\n\n4. **NCBI GEO (Gene Expression Omnibus)** - Contains vast amounts of RNA-seq data, though processing levels vary. Look for datasets that specify they've been processed through standardized pipelines.\n\nFor NF-specific comparisons, the NF Data Portal itself is developing standardized processing pipelines for genomic and transcriptomic data through the Neurofibromatosis Therapeutic Acceleration Program (NTAP). These processed datasets on the portal would be ideal for direct comparison since they use consistent methodologies.\n\nThe key advantage of these resources is that they provide data processed through standardized, well-documented pipelines, which is essential for meaningful cross-dataset comparisons with your NF data."
+    },
+    {
+      "question": "A contributor wants to submit unpublished, proprietary information about a newly developed cell line to NF Research Tools Central. What should they do before submitting?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/neurofibromatosis-research-tools-database",
+        "https://help.nf.synapse.org/NFdocs/how-to-contribute-a-tool"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Speak with their institutional technology transfer office to confirm there are no restrictions on sharing the information publicly",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Before submitting unpublished, proprietary information about a newly developed cell line to NF Research Tools Central, the contributor should speak with their institutional technology transfer office. This consultation is important to confirm any restrictions on how and when information related to the tool may be shared publicly, since all contributed information will be made publicly available in NF Research Tools Central.\n\nAdditionally, the documentation emphasizes that non-public information should not be submitted without permission from the tool developer. Contributors should also ensure their submissions abide by the Synapse Code of Conduct and adhere to the resource submission rubric. The database welcomes contributions at all stages of tool development, including unpublished tools, particularly if the contributor envisions sharing the tool publicly or is seeking collaborators to help validate and improve it.\n\nFor specific questions about the submission process, contributors can contact nf-osi@sagebionetworks.org or use the \"Need more help?\" button on the NF Data Portal."
+    },
+    {
+      "question": "When navigating the NF Data Portal, which section would a researcher use to browse and filter all studies associated with a particular funding initiative, and where would they find detailed filtering instructions?",
+      "persona": "REUSER",
+      "cross_page": true,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/navigating-the-portal"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/navigating-the-portal",
+        "https://help.nf.synapse.org/NFdocs/accessing-data"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "The 'Explore' tab's Initiatives or Studies pages; filtering instructions are in the 'Accessing and Reusing Data' section of the docs site",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "When navigating the NF Data Portal, researchers can browse and filter studies associated with a particular funding initiative using the **Explore** section, specifically through two main approaches:\n\n1. **Studies Page**: Under the Explore tab, researchers can access the Studies page which lists all studies. This page includes filtering tools that allow users to narrow down their search to find studies associated with specific funding initiatives.\n\n2. **Initiatives Page**: Alternatively, researchers can use the Initiatives page (also under Explore) which lists all funding initiatives. From here, they can select a specific initiative of interest to visit that program's specific page, which will display all of its associated projects and studies.\n\nFor detailed filtering instructions, researchers can find comprehensive guidance in the NF Data Portal documentation. The documentation specifically mentions that each of the Explore pages \"have helpful filtering tools in order to narrow down your search and find precisely the data you're looking for\" and directs users to find \"more information on the Explore tab and detailed instructions for using the filtering tools\" in the documentation site.\n\nThe filtering tools are typically located on the left side of each page, with visualization charts on top and data tables below. These tools allow researchers to apply various filters to narrow down their search results based on specific criteria related to funding initiatives and other study characteristics."
+    },
+    {
+      "question": "Which of the following organizations is listed as a Funding Organization on the NF Data Portal?",
+      "persona": "FUNDER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about/portal-structure"
+      ],
+      "cited_urls": [],
+      "attribution_hit": false,
+      "correct_answer": "Children's Tumor Foundation (CTF)",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "<chat>\nI can see the funding organizations listed in the NF Data Portal. The portal tracks several funding agencies including CDMRP, CTF, GFF, NFRI, NIH-NCI, and NTAP. However, I notice you mentioned \"which of the following organizations\" but didn't provide me with the specific organizations you'd like me to check. Could you please provide the list of organizations you'd like me to verify against the portal's funding organization database?\n</chat>\n<actions>\n  <redirect>\n    <target>/Explore/Funders</target>\n    <query><![CDATA[\n{\n  \"sql\": \"SELECT * FROM syn16858699\",\n  \"additionalFilters\": [],\n  \"selectedFacets\": [],\n  \"includeEntityEtag\": false,\n  \"isConsistent\": true\n}\n    ]]></query>\n  </redirect>\n</actions>"
+    },
+    {
+      "question": "In the context of Hackathons, what does a Project mean?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about/portal-structure"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/portal-structure"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "A hackathon project is a mini-research project not associated with a grant, describing the result of a hackathon or other collaborative science event",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "In the context of Hackathons on the NF Data Portal, a \"Project\" is defined as a mini-research project that is not associated with a traditional grant. Instead, it describes the result of a hackathon or other collaborative science event. These projects emerge from events like the 2021 Hack for Rare, where community members use existing data, software, and other resources to develop research projects over the course of a weekend or a few weeks."
+    },
+    {
+      "question": "When submitting Whole Exome Sequencing (WES) data for genomic processing on the NF Data Portal, what additional file is required beyond the standard annotation terms?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/data-processing/genomic-data-processing-data-eligibility-criteria-"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/genomic-data-processing-data-eligibility-criteria-"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "A BED file associated with the library preparation method",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "When submitting Whole Exome Sequencing (WES) data for genomic processing on the NF Data Portal, a BED file is required as an additional file beyond the standard annotation terms. The BED file must be associated with the library preparation method used for each WES dataset and needs to be uploaded and made available to the NF-OSI Sage Team for the dataset to be eligible for processing. Without this BED file, WES files are not eligible for variant calling. The BED file contains information about the target regions that were sequenced during the exome capture process, which is essential for proper genomic analysis and variant calling."
+    },
+    {
+      "question": "For Bulk RNA Sequencing data submitted to the NF Data Portal, which annotation terms are listed as optional but recommended?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/data-processing/genomic-data-processing-data-eligibility-criteria-"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/genomic-data-processing-data-eligibility-criteria-"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "isStranded and readPairOrientation",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "For Bulk RNA Sequencing data submitted to the NF Data Portal, the annotation terms that are listed as optional but recommended are:\n\n1. **isStranded** - This should be either \"yes\" or \"no\"\n2. **readPairOrientation** - Indicates the read pair orientation, such as forward or reverse\n\nThese terms are marked with an asterisk (*) in the annotation requirements table and explicitly noted as \"optional but recommended\" in the documentation."
+    },
+    {
+      "question": "According to the NF Data Portal documentation, which step-by-step resource is available to help a researcher export data to a compute platform like CAVATICA, and where can they also learn how to upload data to Synapse?",
+      "persona": "REUSER",
+      "cross_page": true,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about/portal-structure",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/resource-hub"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/downloading-data-from-the-nf-data-portal",
+        "https://help.nf.synapse.org/NFdocs/resource-hub",
+        "https://help.nf.synapse.org/NFdocs/how-to-upload-data"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "A video tutorial is available for exporting data to CAVATICA, and a separate video tutorial is available for uploading data to Synapse - both found in the Step-by-step guides and videos resource hub",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "According to the NF Data Portal documentation, there is a video tutorial available that provides step-by-step instructions for exporting data from the NF Data Portal to a compute platform like CAVATICA. This tutorial specifically \"outlines the steps to export data from NF Data Portal to an AWS based compute platform called CAVATICA.\"\n\nFor learning how to upload data to Synapse, researchers can access a comprehensive video tutorial called \"Uploading Data via the Synapse UI\" which covers steps 3-4 of the data upload process. This is part of a series of three videos on sharing data, with the first video being \"Introduction to Sharing Data\" that covers steps 1-2. The documentation also provides detailed written step-by-step instructions for uploading data, including account certification, locating your Synapse project, creating folders, and the actual upload process using various methods (web UI, Python client, command-line client, or R client)."
+    },
+    {
+      "question": "In Synapse Curator, what happens to your intermediate changes while you are filling out a metadata grid?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/synapse-curator-transition-guide"
+      ],
+      "cited_urls": [],
+      "attribution_hit": false,
+      "correct_answer": "Each action is automatically saved, so you can use Undo and Redo.",
+      "judge_score": 0,
+      "correct": false,
+      "agent_response": "I apologize, but I don't have specific information about what happens to intermediate changes while filling out a metadata grid in Synapse Curator. The search results didn't return relevant documentation about this particular aspect of the Curator tool.\n\nFor detailed information about Synapse Curator's behavior regarding intermediate changes, auto-saving, or session management while working with metadata grids, I'd recommend:\n\n1. Checking the official Synapse documentation at docs.synapse.org\n2. Contacting Synapse support directly through their help desk\n3. Consulting the Synapse community forums where other users may have experience with this specific workflow\n\nThis would ensure you get accurate, up-to-date information about how the Curator handles your work-in-progress changes."
+    },
+    {
+      "question": "Which of the following correctly describes a key limitation of MySQL Full Text Search as used in the NF Research Tools Central?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database/tips-for-search"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/tips-for-search"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "It does not perform stemming, so searching 'plexiform neurofibromas' may yield worse results than searching 'plexiform neurofibroma'.",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Based on the search results, there are several key limitations of MySQL Full Text Search as used in the NF Research Tools Central:\n\n1. **No spelling error tolerance** - The system doesn't understand spelling mistakes well, so users must ensure correct spelling for effective searches.\n\n2. **No stemming capability** - MySQL Full Text Search does not perform \"stemming\" to identify the root of words, meaning it won't recognize different forms of the same word. Users get better results by avoiding pluralization or suffixes (like -ing), and should search for \"plexiform neurofibroma\" instead of \"plexiform neurofibromas.\"\n\n3. **Short term limitations** - The search ignores short terms that are not exact matches (4 or fewer characters), so while \"NF1\" will produce results, short terms embedded within longer words (like \"grow\" inside \"growing\") will not be found.\n\n4. **Requirement for exact matching** - Users need to search for exact matches rather than relying on the system to interpret variations or related terms.\n\nThe documentation emphasizes that users should check for spelling errors, avoid pluralization or suffixes, and utilize precise terms that exactly match their intended search criteria for optimal results."
+    },
+    {
+      "question": "A researcher wants to perform collaborative genomic analyses on NF data from the portal without manually downloading and re-uploading files. Which platform currently has an active Synapse DRS integration that enables this workflow?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/accessing-data/tools-and-environments-for-data-processing-and-ana"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/downloading-data-from-the-nf-data-portal",
+        "https://help.nf.synapse.org/NFdocs/resource-hub"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Cavatica (Seven Bridges)",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Based on the NF Data Portal documentation, the platform that currently has an active Synapse DRS integration enabling collaborative genomic analyses without manual file downloads is CAVATICA. The documentation specifically mentions that you can export data from the NF Data Portal to CAVATICA, which is described as \"an AWS based compute platform.\" This integration allows researchers to perform computational analyses on NF data directly within CAVATICA's cloud environment without needing to download and re-upload files manually.\n\nThe NF Portal documentation includes video tutorials that demonstrate how to export data from the NF Data Portal to CAVATICA for analysis, and there are step-by-step guides available for creating a CAVATICA account and connecting it to the NF Data Portal."
+    },
+    {
+      "question": "What is the key difference between using a DRS-connected platform versus a self-managed compute environment (e.g., institutional HPC) for accessing NF portal data?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/accessing-data/tools-and-environments-for-data-processing-and-ana"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/resource-hub",
+        "https://help.nf.synapse.org/NFdocs/downloading-data-from-the-nf-data-portal"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "DRS-connected platforms allow direct data access from Synapse without manual download/upload, while self-managed compute requires manual data transfer.",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Based on the NF Data Portal documentation, there are key differences between using a DRS-connected platform (like CAVATICA) versus a self-managed compute environment for accessing NF portal data:\n\n**DRS-Connected Platforms (e.g., CAVATICA):**\n- Provide direct integration with the NF Data Portal through AWS-based cloud computing\n- Allow you to export data directly from the portal to the compute platform without manual downloads\n- Offer streamlined workflows where data can be accessed and analyzed in the cloud environment\n- Handle the technical infrastructure and connectivity automatically\n- Provide video tutorials and step-by-step guides specifically for connecting to the NF Data Portal\n\n**Self-Managed Compute Environments (e.g., Institutional HPC):**\n- Require you to manually download data to your local computer or institutional systems first\n- Need you to manage the data transfer process using tools like the Synapse R Client\n- Require setting up your own computational infrastructure and managing storage\n- Give you full control over your computing environment but require more technical setup\n- May involve additional steps for data security and access control compliance\n\nThe main advantage of DRS-connected platforms is the seamless integration and reduced manual data handling, while self-managed environments offer more control but require additional setup and data transfer steps."
+    },
+    {
+      "question": "A contributor has been using the Data Curator App (DCA) to annotate a dataset and now wants to view and update that metadata using Synapse Curator. Is this supported, and under what condition?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/synapse-curator-transition-guide"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/NFdocs/how-to-annotate-data"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Yes - as long as a curation task has been set up for that dataset in Synapse Curator, DCA-annotated metadata can be viewed and updated there.",
+      "judge_score": 0,
+      "correct": false,
+      "agent_response": "Based on the available documentation, the Data Curator App (DCA) is the primary tool used for annotating datasets in the NF Data Portal ecosystem. The DCA workflow involves generating metadata templates, filling them out (typically in Google Sheets), validating the metadata, and then submitting annotations to Synapse. However, the documentation does not specifically mention \"Synapse Curator\" as a separate tool or provide information about compatibility between the DCA and a tool called \"Synapse Curator\" for viewing and updating metadata that was originally created through the DCA.\n\nThe available documentation focuses on the Data Curator App as the standard workflow for metadata annotation, which includes steps for generating templates, filling in metadata, validating submissions, and applying annotations to files in Synapse. If you need to view or update metadata that was created using the DCA, I would recommend contacting the NF-OSI support team at nf-osi@sagebionetworks.org for specific guidance about compatibility with other curation tools and workflows for updating existing metadata."
+    }
+  ],
+  "errors": []
+}

--- a/benchmark/general-help/eval_results_20260514T223326Z.json
+++ b/benchmark/general-help/eval_results_20260514T223326Z.json
@@ -1,0 +1,829 @@
+{
+  "timestamp": "20260514T223326Z",
+  "config": {
+    "agent_id": "2COISTBHRB",
+    "agent_alias_id": "TSTALIASID",
+    "judge_model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "dataset": "help_qa_dataset_anthropic.json"
+  },
+  "results": [
+    {
+      "question": "What is the default license applied to non-human data submitted to the NF Data Portal?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/about-data-licensing"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/about-data-licensing"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "CC0 (No Rights Reserved)",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "The default license applied to non-human data submitted to the NF Data Portal is CC0 (Creative Commons Zero). This is described as a \"no rights reserved\" license by Creative Commons, which effectively places the data in the public domain and makes it truly open data available to anyone without restriction. Data contributors can select the license that applies to their data during submission, with CC0 being the default option specifically for non-human data."
+    },
+    {
+      "question": "What is the maximum file download size supported through the Synapse web interface?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/accessing-data"
+      ],
+      "cited_urls": [],
+      "attribution_hit": false,
+      "correct_answer": "5 GB or 100 files",
+      "judge_score": 0,
+      "correct": false,
+      "agent_response": "I apologize, but I wasn't able to find specific information about the maximum file download size supported through the Synapse web interface in the available documentation. The search didn't return detailed results about file size limitations for web-based downloads.\n\nFor accurate information about Synapse's file download size limits through the web interface, I recommend:\n\n1. Checking the official Synapse documentation at docs.synapse.org\n2. Contacting Synapse support directly through their help desk\n3. Consulting the Synapse community forums where technical limitations are often discussed\n\nGenerally, for very large files, Synapse typically recommends using their command-line tools or programmatic clients (Python/R) rather than the web interface, but I cannot provide the specific size threshold without access to the current technical specifications."
+    },
+    {
+      "question": "Which of the following correctly describes the relationship between Synapse and the NF Data Portal?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-upload-data",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "Synapse is the back-end platform where data is uploaded and stored, while the NF Data Portal is the front-end user interface for exploring that data.",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "The NF Data Portal and Synapse have a complementary relationship where Synapse serves as the data storage and management backend, while the NF Data Portal functions as the user-facing frontend. Specifically, Synapse is the data management software platform developed by Sage Bionetworks that allows for collaborative data curation, analysis, computational modeling, and data tracking in a private workspace. Researchers upload their data to Synapse, where it is stored and managed. The NF Data Portal then serves as the public-facing interface that makes this data searchable and accessible to the research community. Think of Synapse as the back-end infrastructure where all the data lives, and the NF Data Portal as the front-end entry point that allows users to discover, explore, and access that data."
+    },
+    {
+      "question": "According to the NF Data Portal documentation, what is the typical embargo period provided to data contributors after a grant ends before data must be released?",
+      "persona": "FUNDER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/accessing-data"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/accessing-data",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/data-contributor-checklist"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "12-18 months",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "According to the NF Data Portal documentation, data contributors are typically provided an embargo period of 12-18 months after the grant ends to publish their results before data must be released. However, the documentation emphasizes that the specific length of the embargo period varies by funder, and contributors should check with their specific funding agency to confirm the exact duration for their project."
+    },
+    {
+      "question": "A researcher wants to share their NF study data publicly. According to the data sharing steps outlined in the documentation, what is the very FIRST step they should take?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about/about-data-sharing"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-share-data-an-overview",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/frequently-asked-questions"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Get involved with the NF-OSI community and be accepted as a contributor.",
+      "judge_score": 0,
+      "correct": false,
+      "agent_response": "According to the NF Data Portal documentation, the very FIRST step a researcher should take when wanting to share their NF study data publicly is to **become a Registered and Certified User** on Synapse. This involves two parts: first registering for a Synapse account, and second completing the certification quiz. The certification is required to upload data and ensures the researcher has awareness of privacy and security issues associated with using a platform that stores human subjects research data. The certification quiz consists of 15 questions covering the Synapse Commons Data Use Procedure and typically takes around 15-20 minutes to complete."
+    },
+    {
+      "question": "Why does the NF Data Portal documentation recommend using the CC0 license for non-human research data, and how does this connect to data reuse goals?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": true,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/about-data-licensing",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about/about-data-sharing/10-reasons-to-share-your-data"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/about-data-licensing"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "CC0 places data in the public domain without restrictions, enabling reuse and reanalysis to advance new discoveries, which is the goal of the NF Data Portal-and sharing data publicly can also support new collaborations.",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "The NF Data Portal documentation recommends using the CC0 license for non-human research data because it serves as the most effective mechanism for achieving the portal's primary goal of enabling data reuse and advancing scientific discoveries. CC0 effectively places data in the public domain, creating truly open data that is available to anyone without restriction.\n\nThe documentation explains that CC0 is particularly well-suited for raw, experimental data - which represents the immediate output of experiments without analysis or interpretation. This type of data typically doesn't meet the threshold of copyright protection, making CC0 an appropriate choice for placing it in the public domain.\n\nThe connection to data reuse goals is fundamental: CC0 removes legal barriers that could otherwise deter researchers from reanalyzing and repurposing data. The documentation notes that in the United States, copyright law is so complex that imposing any restrictions - no matter how reasonable they might seem - actually discourages reuse. By eliminating these legal complexities, CC0 enables researchers to confidently reanalyze and repurpose data to advance new discoveries.\n\nAdditionally, CC0 aligns with broader scientific and funding requirements. It's recognized as a respected standard used by many other repositories, and this type of public domain release may be required by publicly funded research projects, making it both a practical and often mandatory choice for data contributors."
+    },
+    {
+      "question": "Which file formats are available for downloading the NF-OSI Data Dictionary for integration into developer tools and workflows?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/annotation-dictionary-browser"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/frequently-asked-questions",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/annotation-dictionary-browser"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "JSON-LD, JSON Schema, and LinkML (yaml format)",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "The NF-OSI Data Dictionary is available for download in multiple file formats to support integration into developer tools and workflows. The dictionary is hosted on GitHub in CSV and JSON formats as versioned releases. Additionally, for developers specifically looking to integrate the dictionary into their tools and workflows, it's available in three specialized formats: JSON-LD, JSON Schema, and LinkML. These formats provide structured data definitions that can be easily consumed by various development frameworks and automated systems."
+    },
+    {
+      "question": "According to the Antibody Epitope Nomenclature guidelines, how should a phospho-specific epitope targeting NF1 at serine position 2515 be correctly formatted?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database/antibody-epitope-nomenclature"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database/antibody-epitope-nomenclature"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "phospho-NF1 (Ser2515)",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "According to the Antibody Epitope Nomenclature guidelines from the NF Data Portal, a phospho-specific epitope targeting NF1 at serine position 2515 should be formatted as:\n\n**phospho-NF1 (Ser2515)**\n\nThe formatting follows these specific rules:\n- Use the prefix \"phospho-\" for phospho-specific epitopes\n- Follow with the gene/protein symbol (NF1)\n- Include the phospho-target in parentheses using the three-character amino acid abbreviation (Ser) followed by the position number (2515)\n\nThis exact example is provided in the documentation as a valid epitope format."
+    },
+    {
+      "question": "During the project close-out process on Synapse, who is responsible for confirming that all data listed on the data sharing plan are uploaded?",
+      "persona": "FUNDER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/for-the-funding-organizations/draft-checklist-to-close-a-project"
+      ],
+      "cited_urls": [],
+      "attribution_hit": false,
+      "correct_answer": "Sage Bionetworks",
+      "judge_score": 0,
+      "correct": false,
+      "agent_response": "I apologize, but I don't have specific information available in my knowledge base about the project close-out process on Synapse and who is responsible for confirming that all data listed on the data sharing plan are uploaded. \n\nThis appears to be a detailed procedural question about Synapse's project management workflows that would require access to specific documentation about Synapse's data management policies and procedures. For the most accurate and up-to-date information about project close-out responsibilities, I'd recommend:\n\n1. Consulting the official Synapse documentation\n2. Contacting Synapse support directly\n3. Checking with your institution's data management office or research administration team\n4. Reviewing any project agreements or contracts that specify data sharing responsibilities\n\nThe responsibility could potentially lie with project investigators, data managers, institutional administrators, or Synapse platform administrators, but I cannot provide a definitive answer without access to the specific procedural documentation."
+    },
+    {
+      "question": "What are the three ways listed to contact the NF Data Portal support team for help?",
+      "persona": "X",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contact-us"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contact-us"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "Filing a support ticket, scheduling a Zoom appointment, and emailing nf-osi@sagebionetworks.org",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Based on the NF Data Portal documentation, there are three ways listed to contact the NF Data Portal support team for help:\n\n1. **Visit their service portal and file a support ticket** - This appears to be their help desk system for submitting formal support requests\n2. **Schedule a Zoom appointment with their team** - Direct video consultation for more complex issues  \n3. **Email them at nf-osi@sagebionetworks.org** - Direct email contact for questions, suggestions, or other feedback\n\nThese contact methods are provided to help users get assistance with questions about the NF Data Portal, data submission, or other portal-related issues."
+    },
+    {
+      "question": "According to the Contributing Data overview, what are the stages a data contributor must follow when submitting data to the NF Data Portal?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/data-contributor-checklist",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "How to Share Data (Overview), How to Format Data, How to Organize Data, How to Upload Data, How to Annotate Data",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Based on the Contributing Data overview documentation, data contributors must follow five distinct phases when submitting data to the NF Data Portal:\n\n1. **Initial Award Phase** - The beginning phase when funding is first received\n2. **Data Generation Phase** - The period during which research data is being generated\n3. **Project Completion (Under Embargo) Phase** - When the project is completed but data is still under embargo\n4. **Data Publication Prep Phase** - Preparing data for publication and public release\n5. **Post-Publication Phase** - After the data and associated publications are made public\n\nAdditionally, the overview outlines specific stages that contributors need to follow for the technical aspects of data submission, which are detailed in separate documentation pages:\n\n- How to Share Data (Overview)\n- How to Format Data  \n- How to Organize Data\n- How to Upload Data\n- How to Annotate Data\n\nContributors can use the data contributor checklist to ensure they have completed all required steps outlined in these documents. The documentation notes that projects funded by NF Data Portal partners may have additional data sharing obligations as outlined in their funding agreements."
+    },
+    {
+      "question": "When closing a project, what action must Sage take regarding a DOI for the project/dataset, and why is it important for contributors to include it in their manuscripts?",
+      "persona": "FUNDER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/for-the-funding-organizations/draft-checklist-to-close-a-project"
+      ],
+      "cited_urls": [],
+      "attribution_hit": false,
+      "correct_answer": "Sage checks whether a DOI has been minted and, if not, asks the contributor to create one and include it in the manuscript's Data Availability Statement so readers can find the data.",
+      "judge_score": 0,
+      "correct": false,
+      "agent_response": "I apologize, but I was unable to find specific information in the available documentation about Sage's DOI requirements when closing projects or the importance of including DOIs in manuscripts. The search results did not return detailed information about project closure procedures or DOI minting requirements.\n\nFor accurate information about DOI requirements during project closure and manuscript citation guidelines, I recommend:\n\n1. Contacting Sage Bionetworks directly through their support channels\n2. Checking the official Synapse documentation on synapse.org\n3. Reviewing any project governance or data management policies provided by Sage\n\nThis information would be important for ensuring proper data citation and maintaining the long-term accessibility and attribution of research datasets."
+    },
+    {
+      "question": "During the Initial Award Phase, what is a consequence of NOT completing the Data Sharing Plan (DSP)?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/data-contributor-checklist"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/data-contributor-checklist"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "It can lead to delays in funding disbursements.",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "During the Initial Award Phase, NOT completing the Data Sharing Plan (DSP) can lead to delays in funding disbursements. The DSP is a critical requirement that must be completed before funding can proceed, and failure to complete it will impact the timeline of your award."
+    },
+    {
+      "question": "Which of the following sequencing assays does NF-OSI support for Copy Number Variation (CNV) processing?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/data-processing/eligible-datatypes-and-workflows"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/data-processing/eligible-datatypes-and-workflows"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "Whole Genome Sequencing (WGS) only",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Based on the NF-OSI data processing workflows, Copy Number Variation (CNV) processing is supported for **Whole Genome Sequencing (WGS)** only. \n\nThe assay-specific workflow availability shows that:\n- **WGS**: \u2705 CNV processing is available\n- **WES (Whole Exome Sequencing)**: \u2716\ufe0f CNV workflow is available for this data type, but NF-OSI will not provide this processing\n- **Bulk RNAseq**: Not applicable for CNV processing\n- **Single Cell RNAseq**: Not applicable for CNV processing\n\nThe documentation notes that for WES, while the CNV workflow is technically available, NF-OSI has decided not to provide this processing based on recommendations from scientists and engineers at Sage who identified various problems in interpretation of processed CNV data from WES workflows during downstream analysis."
+    },
+    {
+      "question": "How frequently is the data in the ProjectLIVE app updated to reflect changes in Synapse studies?",
+      "persona": "FUNDER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/for-the-funding-organizations/how-to-use-projectlive/faqs"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/for-the-funding-organizations/how-to-use-projectlive/faqs"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "Daily",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "The ProjectLIVE app updates its data daily to reflect changes in Synapse studies. The app is directly linked to the studies on Synapse, so the data displayed in ProjectLIVE reflects the same information as in Synapse with daily updates. This includes daily tracking of data file uploads and annotations generated by these studies.\n\nHowever, there are some exceptions to this daily update schedule. For \"internal milestone\" tracking, while ProjectLIVE updates daily for studies with data sharing plans that have been added to Synapse, the addition of new data sharing plans occurs only every 6 months. This means that changes or updates to milestones or data sharing plans from within the last 6 months may not yet be reflected in the tracker.\n\nAdditionally, publication information is also updated daily, but this data comes from semi-automated scanning of publication repositories like PubMed for acknowledgments of funding sources. Publications are only added to ProjectLIVE if they acknowledge the organization or grant ID, so some publications that don't reference these identifiers may be missing."
+    },
+    {
+      "question": "In the NF Research Tools Central data model, where is the schema maintained in machine-readable format?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database/data-model-schema"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database/data-model-schema"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "As JSON-LD files on GitHub",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Based on the NF Data Portal documentation, the schema for the NF Research Tools Central data model is maintained in machine-readable JSON-LD format in a GitHub repository. Specifically, the schema files are hosted at: https://github.com/nf-osi/nf-research-tools-schema\n\nThe documentation indicates that in addition to the entity-relationship diagram that describes the data model structure, these JSON-LD files provide the machine-readable schema definition. Changes to the schema are also tracked through release notes in the same repository."
+    },
+    {
+      "question": "According to the Data Contributor Checklist, who must give approval before data can be made public on the NF Data Portal?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/data-contributor-checklist"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/data-contributor-checklist"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "The principal investigator of the study",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "According to the Data Contributor Checklist, the principal investigator must give approval before data can be made public on the NF Data Portal. This requirement is explicitly stated in the Data Publication Prep Phase, where it notes: \"We always require the approval of the principal investigator before making data public.\"\n\nThe process involves the Sage team reaching out to the principal investigator via email during the Data Publication Prep Phase, and the investigator must \"provide your approval to make the data accessible by responding to the email from the Sage team.\" This approval step ensures that the principal investigator has final authority over when their data becomes publicly available on the portal."
+    },
+    {
+      "question": "The NF-OSI data processing pilot initiative covers NTAP-funded projects from which time range, and what kind of data does it aim to uniformly process?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": true,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/data-processing/eligible-datatypes-and-workflows",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/data-processing"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/data-processing",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/data-processing/eligible-datatypes-and-workflows"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "NTAP-funded projects from 2018-2024, focusing on genomic and transcriptomic data",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "The NF-OSI data processing pilot initiative covers NTAP-funded projects from 2018 to 2024. This initiative, supported by the Neurofibromatosis Therapeutic Acceleration Program (NTAP), aims to uniformly process genomic and transcriptomic data on the NF Data Portal using standardized data processing pipelines.\n\nThe specific data types eligible for uniform processing include:\n\n1. **Whole Exome Sequencing (WES)** - focusing on sequencing the coding regions of the genome\n2. **Whole Genome Sequencing (WGS)** - sequencing the entire genome including both coding and non-coding regions\n3. **Bulk RNA Sequencing** - sequencing the transcriptome of bulk cell populations to analyze gene expression levels\n4. **Single Cell RNA Sequencing** - sequencing individual cell transcriptomes to study cell heterogeneity\n\nThe processing workflows available vary by data type and include germline single nucleotide variants (SNV), somatic SNV, copy number variations (CNV), structural variants (SV), microsatellite instability (MSI), and raw counts analysis depending on the specific assay used."
+    },
+    {
+      "question": "What is the primary purpose of the ProjectLIVE app for funding organizations?",
+      "persona": "FUNDER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/for-the-funding-organizations"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/for-the-funding-organizations",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/for-the-funding-organizations/how-to-use-projectlive"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "To consolidate high-level information about individual studies and provide daily tracking of data file uploads and annotations",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "The primary purpose of the ProjectLIVE app for funding organizations is to provide a centralized platform for tracking the impact and progress of their funded research studies. The app was created to help funding organizations understand the impact their organization has made by consolidating high-level information about individual studies present on the NF Data Portal that are funded through their various initiatives.\n\nProjectLIVE provides summary-level information and simple visualizations that allow funding organizations to track their funding portfolio at various levels of granularity through four main modules: Snapshot (bird's eye view of funding portfolio and activity year over year), Publications (longitudinal tracking of publications), Participating Studies (detailed study information with high granularity), and daily tracking of data file uploads and annotations generated by funded studies.\n\nEssentially, ProjectLIVE serves as an effective tool for funding organizations to monitor and understand the tangible outcomes and data generation progress of the innovative studies they support, all in one convenient location."
+    },
+    {
+      "question": "During a study's embargo period, which of the following parties can access the actual data files (not just metadata)?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/frequently-asked-questions"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/accessing-data",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/data-contributor-checklist"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Only the research team, NF-OSI data curation and support staff at Sage Bionetworks, and designated project managers from the funding organization",
+      "judge_score": 1,
+      "correct": false,
+      "agent_response": "During a study's embargo period, access to actual data files is highly restricted. Based on the documentation, the embargo period is typically 12-18 months after a grant ends and is designed to allow data contributors time to publish their results before making data publicly available.\n\nDuring the embargo period, data has an \"Under Embargo\" status, meaning the project may be complete but data is not released for public access. The primary parties who can access actual data files during this period are:\n\n1. **The original data contributors/investigators** - They maintain access to their own data to complete analyses and prepare publications\n\n2. **Journal reviewers** - If reviewers need access to embargoed data for manuscript review, the Sage team can facilitate special access requests through a formal process\n\n3. **Authorized project team members** - Those directly involved in the original study who need continued access for data annotation, curation, and publication preparation\n\nThe embargo period is specifically designed to protect the data contributors' ability to publish first while they complete data annotations and prepare for eventual public release. Access is not generally granted to external researchers or the broader scientific community until the embargo lifts and the data moves to \"Available\" status."
+    },
+    {
+      "question": "What does a researcher need to do before they can download data from the NF Data Portal?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/getting-started"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/getting-started",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/governance-models"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "Register for a Synapse account and agree to the Synapse Terms and Conditions of Use",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "To download data from the NF Data Portal, researchers need to register for a Synapse account and agree to the Synapse Terms and Conditions of Use. While anyone can explore and browse the portal without an account, downloading data requires this registration step.\n\nFor controlled access data, which includes sensitive data or data with greater potential for re-identification, researchers must take additional steps beyond basic registration. They need to request access by reading and electronically agreeing to data-specific terms and providing an intended data use statement.\n\nAll users must also commit to proper attribution requirements. If researchers plan to use any downloaded data in publications (whether open or controlled access), they must include acknowledgement statements that can be found on the Study Details page of each study."
+    },
+    {
+      "question": "According to the NF Data Portal Glossary, what distinguishes a 'Study' from a 'Dataset'?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/glossary"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/glossary"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "A study is the primary unit of data organization representing a research project, while a dataset bundles multiple similar data files into one large bulk file",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "According to the NF Data Portal Glossary, a 'Study' and a 'Dataset' serve different organizational purposes:\n\nA **Study** is the primary unit of data organization in the portal, representing an individual research project with specific objectives and focus. Studies bundle together multiple pieces of project information including study title, summary, lead investigator, access requirements, acknowledgement statements, data files, datasets, metadata files, tools, publications, and related studies. A study is typically associated with a grant (though some studies may span multiple grants or be led by non-grant-funded program partners), and can represent data from human cohorts, model system experiments, cross-consortium analysis efforts, or data associated with specific publications.\n\nA **Dataset**, on the other hand, is a more focused collection that bundles multiple similar data files together into one large bulk file that can be downloaded at once. Datasets range in size from hundreds of files to just a few, and may have been processed or harmonized to improve their usefulness.\n\nIn essence, a Study is the broader research project container that encompasses the entire research effort, while a Dataset is a specific collection of related data files within that study that can be packaged and downloaded together."
+    },
+    {
+      "question": "Under the Controlled Access governance model on the NF Data Portal, how long does a data access approval last before it must be renewed?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/governance-models"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/governance-models"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "1 year",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Under the Controlled Access governance model on the NF Data Portal, data access approval lasts for 1 year before it must be renewed. This means that researchers who have been granted access to controlled access datasets will need to renew their approval annually to maintain their access to the data."
+    },
+    {
+      "question": "A researcher wants to cite data they used from the NF Data Portal in a publication. Which of the following does the documentation recommend including?",
+      "persona": "REUSER",
+      "cross_page": true,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/getting-started",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/frequently-asked-questions"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/frequently-asked-questions"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "The acknowledgement statement from the Study Details page, the Synapse ID or DOI, and a standard NF Data Portal acknowledgement statement",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "When citing data used from the NF Data Portal in a publication, the documentation recommends including several key components:\n\n1. **Use the citation/acknowledgement information from the Study page** for the specific data you are using, including any \"Acknowledgement Statements\" section.\n\n2. **Include persistent identifiers**: Reference the Synapse ID (e.g., syn2343195) or DOI when available (e.g., 10.7303/syn2343195) for the data or study you are referencing. These persistent accession numbers help others find the exact data you used.\n\n3. **Include the NF Data Portal acknowledgement statement**: \"The results published here are in whole or in part based on data obtained from the NF Data Portal (http://www.nf.synapse.org) and made available through the NF Open Science Initiative.\"\n\n4. **Add information to your data availability statement**: Include the DOI in your data availability statement, such as \"Raw data for this manuscript is available on the NF Data Portal (nf.synapse.org) and on Synapse at https://www.doi.org/10.7303/syn2343195.\"\n\nThe documentation emphasizes that including the acknowledgement statement helps the portal team track publications and assess the portal's impact on the research community. Both DOIs and Synapse IDs can be found on the portal Study page for the data you're referencing."
+    },
+    {
+      "question": "When annotating data using the NF Data Curator App, what should you do if your manifest required custom terms not found in the existing dictionary?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-annotate-data"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-annotate-data"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "Email the completed Google Sheet or Excel file to nf-osi@sagebionetworks.org so new terms can be added to the dictionary.",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "When annotating data using the NF Data Curator App and your manifest requires custom terms that are not found in the existing NF-OSI dictionary, you should email the completed Google Sheets or Excel file to nf-osi@sagebionetworks.org. The NF-OSI team will work with you to add your new terms to their dictionary and help get the annotations applied to your data.\n\nThis is different from the standard process where manifests without custom terms can be submitted directly through the \"Submit and Validate Metadata\" tab in the NF Data Curator app. When custom terms are needed, manual review and dictionary updates are required before the annotation process can be completed."
+    },
+    {
+      "question": "According to the NF Data Portal's data formatting guidelines, which level of RNA-seq data is considered 'raw'?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-format-your-data"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-format-your-data"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "FASTQ or unaligned BAM/CRAM files",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "According to the NF Data Portal's data formatting guidelines, for RNA-seq data, the \"raw\" level corresponds to FASTQ files, unaligned BAM files, or CRAM files. This is consistent with the portal's definition that raw data represents the most unprocessed form of information from a single sample.\n\nThe guidelines distinguish between raw data, semi-processed data, and processed data for RNA sequencing:\n- **Raw data**: FASTQ, unaligned BAM, CRAM files\n- **Semi-processed data**: aligned BAM files  \n- **Processed data**: counts matrices or quantification files (like quant.sf files generated by Salmon-based RNA-seq workflows)\n\nThe portal follows level nomenclature that cross-references with the NCI Genomic Data Commons data levels, where 'raw' corresponds to Level 1 data."
+    },
+    {
+      "question": "What is the correct folder structure for raw data files in a Synapse project on the NF Data Portal?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-organize-data"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-organize-data"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "Files should be placed inside a dataset subfolder under 'Raw Data', not directly under 'Raw Data' itself.",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Based on the NF Data Portal documentation, the correct folder structure for raw data files in a Synapse project follows a specific hierarchy. Your Synapse project will typically be set up with these top-level folders:\n\n- **Raw Data** or **Data** - contains subfolders organized by expected datasets\n- **Milestone Reports** or **Reporting** - contains generated reports for the project\n- **Data Sharing Plan** - contains versioned copies of your Data Sharing Plan\n- **Analysis** - figures or other outputs not considered \"raw data\"\n\nFor the Raw Data folder specifically, it must contain subfolders for each dataset type based on your data sharing plan. This format is required for your data to be detected by the NF Data Portal's data curation application.\n\nThe typical structure within the Raw Data folder looks like this:\n\n```\nRaw Data\n\u251c\u2500\u2500 Imaging\n\u2502   \u251c\u2500\u2500 img1.tiff\n\u2502   \u251c\u2500\u2500 img2.tiff\n\u2502   \u2514\u2500\u2500 manifest.csv\n\u251c\u2500\u2500 Cognitive Assessments\n\u2502   \u251c\u2500\u2500 a_visit.xlsx\n\u2502   \u251c\u2500\u2500 b_visit.xlsx\n\u2502   \u2514\u2500\u2500 manifest.csv\n\u2514\u2500\u2500 RNA-seq\n    \u251c\u2500\u2500 abc.fq.gz\n    \u251c\u2500\u2500 def.fq.gz\n    \u2514\u2500\u2500 manifest.csv\n```\n\nImportant requirements:\n- Files should be placed in folders under Raw Data, not directly under Raw Data itself, even if there's only one type of dataset\n- Each dataset folder is automatically tagged with the key-value pair `contentType=dataset`\n- Each dataset folder should include a manifest.csv file for metadata\n- Following this structure makes annotation and data management easier for both contributors and NF-OSI staff"
+    },
+    {
+      "question": "What types of research tools are currently accepted for submission to NF Research Tools Central?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database/how-to-contribute-a-tool"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database/how-to-contribute-a-tool",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "Animal models, cell lines, antibodies, genetic reagents, and biobanks",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "NF Research Tools Central currently accepts submissions for five main categories of research tools: animal models, cell lines, antibodies, genetic reagents, and biobanks. These tools must be related to the study of neurofibromatosis type 1 (NF1), neurofibromatosis type 2 (NF2), or schwannomatosis.\n\nMore specifically, the accepted tool types include:\n\n\u2022 **Cell lines**: Immortalized cell lines or primary cell cultures that exist in sufficient quantity to be shared\n\u2022 **Animal models**: Genetically modified models of any species, as well as well-characterized and shareable xenograft models  \n\u2022 **Antibodies**: Any commercially available or self-distributed antibodies for NF-relevant targets\n\u2022 **Genetic reagents**: Plasmids, guide RNAs, useful primers, or other genetic tools for studying NF\n\u2022 **Biobanks**: Tissue or other biospecimen repositories containing NF tumors or other NF-relevant biospecimens\n\nThe database welcomes contributions at all stages of tool development and characterization, including both published and unpublished tools. Researchers are encouraged to submit tools in development if they are seeking collaborators to help validate and improve the tool. The key requirement is that you must envision sharing the tool with the public, as all contributed information will be made publicly available through NF Research Tools Central."
+    },
+    {
+      "question": "A researcher wants to reuse single-cell RNA sequencing data from the NF Data Portal. According to the data formatting guidelines, what processed file format is required for single-cell/single-nucleus RNA-seq data?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-format-your-data"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-format-your-data"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "TSV (processed expression matrix) and hda5/hdf5 format following the cellxgene required format",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "For single-cell RNA sequencing data in the NF Data Portal, the data formatting guidelines require both raw and processed files. For the processed file format specifically, the guidelines require TSV (processed expression matrix) and hda5/hdf5 format following the cellxgene required format. The hda5 format is a type of hdf5 file that must comply with the cellxgene formatting standards for single-cell data."
+    },
+    {
+      "question": "Which types of observations are explicitly stated as NOT acceptable when contributing to the NF Research Tools Central observation database?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database/how-to-contribute-an-observation"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database/how-to-contribute-an-observation"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "Observations that are crude, derogatory, or disparaging",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "According to the NF Research Tools Central contribution guidelines, observations that are \"crude, derogatory, or disparaging will not be accepted\" in the observation database. The documentation specifies that acceptable observations include general comments and reviews, usage instructions, depositor comments, issues, and any scientific observations noted from use, while explicitly excluding observations that contain inappropriate language or content that could be considered offensive or negative toward others."
+    },
+    {
+      "question": "What is the correct order of steps to begin sharing data on the NF Data Portal?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-share-data-an-overview"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/data-contributor-checklist"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "Register on Synapse and get certified -> Complete a data sharing plan -> Upload data -> Annotate data",
+      "judge_score": 1,
+      "correct": false,
+      "agent_response": "Based on the NF Data Portal documentation, the correct order of steps to begin sharing data follows a structured process with five distinct phases. For the immediate data sharing process, there are specific stages you should follow in order:\n\n1. **How to Share Data (Overview)** - Start with understanding the overall process\n2. **How to Format Data** - Prepare your data in the correct format\n3. **How to Organize Data** - Structure your data properly\n4. **How to Upload Data** - Upload your prepared data to the portal\n5. **How to Annotate Data** - Add proper metadata and annotations\n\nOnce you're familiar with these instructions, you can use the Data Contributor Checklist to ensure you have completed all required steps. The portal also recognizes five broader phases in the data contribution lifecycle: Initial Award Phase \u2192 Data Generation Phase \u2192 Project Completion (Under Embargo) Phase \u2192 Data Publication Prep Phase \u2192 Post-Publication Phase.\n\nIt's important to note that if your project has been funded by one of the NF Data Portal partners, you may have additional data sharing obligations outlined in your agreement with the funder."
+    },
+    {
+      "question": "What does the Synapse certification quiz consist of, and approximately how long does it take?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-share-data-an-overview"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-share-data-an-overview",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/frequently-asked-questions",
+        "https://s3.amazonaws.com/static.synapse.org/governance/SynapseCommonsDataUseProcedure.pdf?v=4"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "15 questions covering the Synapse Commons Data Use Procedure, typically taking 15-20 minutes",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "The Synapse certification quiz consists of 15 questions that cover the Synapse Commons Data Use Procedure. The quiz ensures your understanding of the rules and policies governing data sharing on Synapse, including privacy and security issues associated with using a platform that stores human subjects research data. The quiz typically takes around 15-20 minutes to complete.\n\nCertification is required if you plan to upload data to your project, as it provides awareness of ethical, legal, and technical issues associated with using genomic and health information in the Synapse environment. Once certified, you gain full access to Synapse features, enabling you to upload files and tables and create folders."
+    },
+    {
+      "question": "When manually creating a folder in Synapse for data upload, what annotation must be added to make the folder appear in the Data Curator App?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-upload-data"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-upload-data"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "contentType = dataset",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "When manually creating a folder in Synapse for data upload, you must add the annotation `contentType = dataset` to make the folder appear in the Data Curator App. This annotation is required for the Data Curator App to recognize the folder as a dataset folder that can be annotated. You can manually add this annotation by clicking the annotation folder icon and adding the Key \"contentType\" with the value \"dataset\"."
+    },
+    {
+      "question": "Which ProjectLIVE module allows a funder to see a list of all newly uploaded files within a customizable recent time window?",
+      "persona": "FUNDER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/for-the-funding-organizations/how-to-use-projectlive"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/for-the-funding-organizations/how-to-use-projectlive",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/for-the-funding-organizations/how-to-use-projectlive/projectlive-use-cases"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "New Submissions",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "The **New Submissions** module in ProjectLIVE allows funders to see a list of all newly uploaded files within a customizable recent time window. This module provides a summary of new file submissions that can be filtered by the number of days you specify. By default, it shows files uploaded within the last 60 days, but you can customize this time window by entering any number of days you wish in the \"Display files uploaded within the last N days\" field."
+    },
+    {
+      "question": "As a researcher reusing NF Data Portal data, where would you find extensive individual-level clinical data such as patient demographics and phenotypes?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/accessing-data/metadata"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about/about-data-sharing/other-publicly-available-data-resources",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/accessing-data",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/resource-hub",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about/portal-structure"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "If available, as a .csv file or Synapse table in the project, though these are usually harder for contributors to share in full detail and often have more restrictions",
+      "judge_score": 1,
+      "correct": false,
+      "agent_response": "For extensive individual-level clinical data such as patient demographics and phenotypes in the NF Data Portal, you would primarily find this information in controlled access datasets that require special permissions to access. The documentation mentions that access levels are designated with symbols: \ud83d\udd12 for controlled access (requires dataset-specific permissions/access requests) and \u2705 for open access.\n\nThe Johns Hopkins Biospecimen Repository is specifically mentioned in the documentation as an example of controlled access data that contains clinical information. This type of data typically requires researchers to submit access requests and meet specific criteria before being granted permission to download and use the data.\n\nIndividual-level clinical data including demographics and detailed phenotype information is generally housed in controlled access datasets due to privacy protections and regulatory requirements around patient data. These datasets often contain sensitive information that cannot be made publicly available without proper authorization and data use agreements.\n\nThe NF Data Portal primarily contains sequencing data such as RNA sequencing and whole exome sequencing, along with various imaging assays. While the portal does collect scientific metadata about experimental assays and general data project information, the most comprehensive individual-level clinical data would be found in the controlled access portions of specific studies and datasets.\n\nTo access such clinical data, researchers would need to navigate to the Datasets section of the portal, identify studies with controlled access requirements, and follow the appropriate data access request procedures. The portal's data standards are designed to support data sharing while maintaining appropriate privacy protections for patient information."
+    },
+    {
+      "question": "A contributor wants to update a tool they previously submitted to the NF Research Tools Central. They also want to upload a corrected dataset to Synapse. Which contact channel or mechanism is correct for each action?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": true,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-upload-data",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database/how-to-update-a-contribution"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database/how-to-update-a-contribution"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "Tool updates go through the Sage Bionetworks help portal (selecting 'NF Research Tools Central' -> 'Update a Research Tool or Observation'), while dataset uploads are done directly in Synapse",
+      "judge_score": 1,
+      "correct": false,
+      "agent_response": "For updating a tool previously submitted to the NF Research Tools Central, contributors should use the help portal. Navigate to the help portal, click \"NF Research Tools Central,\" then click \"Update a Research Tool or Observation,\" and complete the prompts. You'll need to provide the name or Resource_id of the tool to be updated, along with a short description of the update requested and timing. Alternatively, you can contact nf-osi@sagebionetworks.org directly for assistance with tool updates.\n\nFor uploading a corrected dataset to Synapse, the search results don't provide specific contact information for general Synapse data uploads. However, given that this is in the context of NF research, you may want to reach out to nf-osi@sagebionetworks.org as they handle NF-related data contributions and could provide guidance on the proper mechanism for uploading corrected datasets to Synapse. For general Synapse support, you would typically use Synapse's standard help channels, but the specific mechanism isn't detailed in the available documentation."
+    },
+    {
+      "question": "When opening a new project on the NF Data Portal, at what step does the study become active and visible on the portal?",
+      "persona": "FUNDER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/for-the-funding-organizations/opening-a-new-project"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/data-contributor-checklist"
+      ],
+      "attribution_hit": false,
+      "correct_answer": "When Sage adds the 'provision' tag to the DSP GitHub pull request, triggering the Synapse Study Creation process",
+      "judge_score": 0,
+      "correct": false,
+      "agent_response": "Based on the NF Data Portal documentation, a study becomes active and visible on the portal during the **data generation phase**. Specifically, during this phase when data are uploaded to Synapse (the backend storage platform), some basic information about the study becomes visible on the portal even though the actual data files are typically not yet available for download.\n\nThe visible information during the data generation phase includes:\n- Study title\n- Study description  \n- Metadata\n\nHowever, it's important to note that full data availability follows a regulated data lifecycle. The study information appears early in the process, but the actual data files become downloadable only after the data curation phase is complete and any embargo periods have ended."
+    },
+    {
+      "question": "A researcher wants to find processed and harmonized RNA-seq datasets aggregated from public repositories to compare with NF data. Which publicly available resource is best suited for this need?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about/about-data-sharing/other-publicly-available-data-resources"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about/about-data-sharing/other-publicly-available-data-resources"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "refine.bio",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "For processed and harmonized RNA-seq datasets aggregated from public repositories to compare with NF data, **refine.bio** is the best publicly available resource. This platform specifically provides processed and harmonized microarray and RNA-seq datasets that have been aggregated from public repositories. It features a user-friendly cohort building and download system that makes it easy to obtain comparison datasets. The resource is open access, requiring only account creation, and is specifically designed for transcriptomic sequencing data analysis."
+    },
+    {
+      "question": "A contributor wants to submit unpublished, proprietary information about a newly developed cell line to NF Research Tools Central. What should they do before submitting?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "Speak with their institutional technology transfer office to confirm there are no restrictions on sharing the information publicly",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Before submitting unpublished, proprietary information about a newly developed cell line to NF Research Tools Central, a contributor should take one critical step: consult with their institutional technology transfer office. This consultation is strongly encouraged to confirm any restrictions on how and when proprietary information related to the research tool may be shared publicly.\n\nIt's important to understand that all contributed information on research tools and associated observations will be made publicly available in NF Research Tools Central. The database accepts tools in any state of development, whether published or unpublished, as long as the contributor envisions sharing the tool with the public. However, non-public information should not be submitted without permission from the tool developer.\n\nContributors can provide details about tool availability, including any Material Transfer Agreement (MTA) requirements, instructions, and contact information for acquiring the research tool. The database encourages contributions at both pre-publication and published stages, with annotations to indicate various stages of tool development and characterization."
+    },
+    {
+      "question": "When navigating the NF Data Portal, which section would a researcher use to browse and filter all studies associated with a particular funding initiative, and where would they find detailed filtering instructions?",
+      "persona": "REUSER",
+      "cross_page": true,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/navigating-the-portal",
+        "https://help.nf.synapse.org/nf-data-portal-documentation"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/navigating-the-portal",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/accessing-data"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "The 'Explore' tab's Initiatives or Studies pages; filtering instructions are in the 'Accessing and Reusing Data' section of the docs site",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "For researchers looking to browse and filter studies associated with a particular funding initiative, there are two primary approaches using the NF Data Portal's navigation structure:\n\n1. **Explore > Initiatives Section**: The primary method is to use the \"Initiatives\" page under the Explore tab. This page lists all funding initiatives, allowing researchers to find and select a specific initiative of interest. Once selected, the initiative's specific page will display all of its associated projects and studies.\n\n2. **Explore > Studies Section**: Alternatively, researchers can use the \"Studies\" page, which lists all studies across the portal. This page includes filtering tools that allow users to narrow down results by various criteria, including funding-related filters.\n\nBoth sections operate with the same general functionality - they provide filtering tools to help researchers narrow down their search and find precisely the data they're looking for.\n\nFor detailed filtering instructions, researchers can find comprehensive guidance in the \"Step-by-step guides and videos\" section of the NF Data Portal documentation. Specifically, the documentation references that detailed instructions for using the filtering tools are available in the \"Accessing and Reusing Data\" section.\n\nThe filtering system works consistently across all Explore pages, featuring:\n- Filter Data By sections on the left side of each page\n- Expandable categories (click the plus sign to reveal filtering options)\n- \"Show more\" options to reveal all filters within each category\n- Search functionality within each filter category\n- Number indicators showing how many results each filter will return\n\nThe documentation includes visual guides and step-by-step instructions, with screenshots and numbered references to help users navigate the various filtering tools effectively."
+    },
+    {
+      "question": "Which of the following organizations is listed as a Funding Organization on the NF Data Portal?",
+      "persona": "FUNDER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about/portal-structure"
+      ],
+      "cited_urls": [],
+      "attribution_hit": false,
+      "correct_answer": "Children's Tumor Foundation (CTF)",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "<chat>\nI can help you check which organizations are listed as funding organizations on the NF Data Portal. The portal includes these funding agencies: CDMRP, CTF (Children's Tumor Foundation), GFF (Gilbert Family Foundation), NFRI, NIH-NCI, and NTAP. However, you haven't provided the specific organizations you'd like me to check. Could you please share the list of organizations you want me to verify?\n</chat>\n<actions>\n  <redirect>\n    <target>/Explore/Funders</target>\n    <query><![CDATA[\n{\n  \"sql\": \"SELECT * FROM syn16858699\",\n  \"additionalFilters\": [],\n  \"selectedFacets\": [],\n  \"includeEntityEtag\": false,\n  \"isConsistent\": true\n}\n    ]]></query>\n  </redirect>\n</actions>"
+    },
+    {
+      "question": "In the context of Hackathons, what does a Project mean?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about/portal-structure"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about/portal-structure"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "A hackathon project is a mini-research project not associated with a grant, describing the result of a hackathon or other collaborative science event",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "In the context of Hackathons in the NF Data Portal, a **Project** refers to a mini-research project that is not associated with a traditional grant. Instead, it describes the result or output of a hackathon or other collaborative science event. These projects represent work developed by community members during events like hackathons (such as the 2021 Hack for Rare), where participants use existing data, software, and other resources to develop research projects over the course of a weekend or a few weeks.\n\nProjects differ from Studies in that Studies are funded research projects associated with grants, while Projects emerge from collaborative community events and hackathons where researchers work together on focused, short-term initiatives using available resources from the portal."
+    },
+    {
+      "question": "When submitting Whole Exome Sequencing (WES) data for genomic processing on the NF Data Portal, what additional file is required beyond the standard annotation terms?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/data-processing/genomic-data-processing-data-eligibility-criteria-"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/data-processing/genomic-data-processing-data-eligibility-criteria-"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "A BED file associated with the library preparation method",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "When submitting Whole Exome Sequencing (WES) data for genomic processing on the NF Data Portal, a BED file associated with the library preparation method is required as an additional file beyond the standard annotation terms. This BED file must be uploaded and made available to the NF-OSI Sage Team for the WES dataset to be eligible for processing and variant calling."
+    },
+    {
+      "question": "For Bulk RNA Sequencing data submitted to the NF Data Portal, which annotation terms are listed as optional but recommended?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/data-processing/genomic-data-processing-data-eligibility-criteria-"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/data-processing/genomic-data-processing-data-eligibility-criteria-"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "isStranded and readPairOrientation",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "For Bulk RNA Sequencing data submitted to the NF Data Portal, the annotation terms that are listed as optional but recommended are marked with an asterisk (*) in the documentation. These are:\n\n1. **isStranded*** - This should be answered as either \"yes\" or \"no\"\n2. **readPairOrientation*** - This indicates the read pair orientation, such as forward or reverse\n\nThese two annotation terms appear in the Bulk and Single Cell RNA Sequencing requirements table with asterisks, indicating they are optional but recommended for submission. All other annotation terms in the list (fileFormat, individualID, specimenID, Assay, Species, libraryPreparationMethod, Platform, readPair, specimenPreparationMethod, and tumorType) are required for genomic processing."
+    },
+    {
+      "question": "According to the NF Data Portal documentation, which step-by-step resource is available to help a researcher export data to a compute platform like CAVATICA, and where can they also learn how to upload data to Synapse?",
+      "persona": "REUSER",
+      "cross_page": true,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/resource-hub",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/about/portal-structure"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/resource-hub",
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/how-to-upload-data"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "A video tutorial is available for exporting data to CAVATICA, and a separate video tutorial is available for uploading data to Synapse - both found in the Step-by-step guides and videos resource hub",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "According to the NF Data Portal documentation, there are several step-by-step resources available to help researchers with data export and upload:\n\nFor exporting data to compute platforms like CAVATICA, there is a dedicated \"Export data to a compute platform like CAVATICA (Video Tutorial)\" that provides step-by-step guidance on this process.\n\nFor learning how to upload data to Synapse, researchers can access the \"Upload Data to Synapse (Video Tutorial)\" which includes a comprehensive video tutorial (uploading_data_via_the_synapse_ui (1080p).mp4) that walks through the process step-by-step.\n\nBoth of these resources are part of the \"Step-by-step guides and videos\" section of the NF Data Portal documentation, which provides comprehensive video tutorials and guides for various data management tasks including account setup, data download, export, upload, and annotation processes."
+    },
+    {
+      "question": "In Synapse Curator, what happens to your intermediate changes while you are filling out a metadata grid?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/synapse-curator-transition-guide"
+      ],
+      "cited_urls": [],
+      "attribution_hit": false,
+      "correct_answer": "Each action is automatically saved, so you can use Undo and Redo.",
+      "judge_score": 0,
+      "correct": false,
+      "agent_response": "I wasn't able to find specific information about what happens to intermediate changes while filling out metadata grids in Synapse Curator. The search didn't return relevant documentation about the auto-save behavior, draft mode, or intermediate change handling in the Synapse Curator interface.\n\nFor accurate information about how Synapse Curator handles your work-in-progress changes while editing metadata grids, I'd recommend:\n\n1. Checking the official Synapse documentation directly\n2. Contacting Synapse support\n3. Testing the behavior yourself by making some changes and observing what happens if you navigate away or refresh the page\n\nThis would help you understand whether changes are automatically saved as drafts, if there's a manual save option, or if unsaved work might be lost."
+    },
+    {
+      "question": "Which of the following correctly describes a key limitation of MySQL Full Text Search as used in the NF Research Tools Central?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database/tips-for-search"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/neurofibromatosis-research-tools-database/tips-for-search"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "It does not perform stemming, so searching 'plexiform neurofibromas' may yield worse results than searching 'plexiform neurofibroma'.",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Based on the documentation for NF Research Tools Central, there are several key limitations of MySQL Full Text Search as used in the system:\n\n1. **No spelling error tolerance** - The search engine does not handle misspellings well, requiring users to ensure correct spelling for optimal results.\n\n2. **No stemming capability** - MySQL Full Text Search does not perform stemming to identify word roots, meaning it won't connect related word forms. Users need to avoid pluralization and suffixes (like -ing) for better results. For example, searching \"plexiform neurofibroma\" works better than \"plexiform neurofibromas.\"\n\n3. **Short term limitations** - The search ignores short terms that are 4 characters or less unless they are an exact match. While terms like \"NF1\" will produce results, short terms embedded within other words (like \"grow\" inside \"growing\") will not be recognized.\n\n4. **Requires precise matching** - Users must utilize precise terms that exactly match their intended search criteria rather than relying on fuzzy matching or approximate searches.\n\nThe documentation emphasizes that while MySQL Full Text Search is computationally and economically efficient, users need to be aware of these limitations and adjust their search strategies accordingly to get the best results."
+    },
+    {
+      "question": "A researcher wants to perform collaborative genomic analyses on NF data from the portal without manually downloading and re-uploading files. Which platform currently has an active Synapse DRS integration that enables this workflow?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/accessing-data/tools-and-environments-for-data-processing-and-ana"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/accessing-data/tools-and-environments-for-data-processing-and-ana"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "Cavatica (Seven Bridges)",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Based on the NF Data Portal documentation, Cavatica (Seven Bridges) is the platform that currently has an active Synapse DRS integration enabling collaborative genomic analyses without manual file transfers. According to the comparison table, Cavatica has \"Synapse integration since 2024\" with \"DRS connection + UI\" as its data access method.\n\nDRS (Data Repository Service) is a standardized API that enables secure, direct data access between repositories and analysis platforms. With this integration, researchers can authorize the connection once, and data appears automatically in their analysis workspace without needing to manually download from Synapse and re-upload to the analysis platform.\n\nThe workflow with Cavatica's DRS integration works as follows: Select your Synapse dataset \u2192 authorize platform access \u2192 data appears ready for analysis. This eliminates the traditional workflow of downloading data from Synapse and then uploading it to an analysis platform.\n\nCavatica offers collaborative workspaces with ergonomic pre-built R and Python environments, making it particularly well-suited for collaborative genomics projects and custom analyses of NF data from the portal."
+    },
+    {
+      "question": "What is the key difference between using a DRS-connected platform versus a self-managed compute environment (e.g., institutional HPC) for accessing NF portal data?",
+      "persona": "REUSER",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/accessing-data/tools-and-environments-for-data-processing-and-ana"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/accessing-data/tools-and-environments-for-data-processing-and-ana"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "DRS-connected platforms allow direct data access from Synapse without manual download/upload, while self-managed compute requires manual data transfer.",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "The key differences between using a DRS-connected platform versus a self-managed compute environment for accessing NF portal data lie in data access methods, workflow efficiency, and infrastructure management.\n\nDRS-connected platforms (like Cavatica) offer streamlined data access through the Data Repository Service API, which provides direct, secure connections between the NF Data Portal's Synapse repository and analysis platforms. This eliminates manual file transfers - you authorize the connection once, and data appears automatically in your workspace without downloading and re-uploading files. The workflow is: select your Synapse dataset \u2192 authorize platform access \u2192 data appears ready for analysis.\n\nIn contrast, self-managed compute environments (like institutional HPC systems) require manual data transfer using command-line tools or APIs. The workflow involves: download data from Synapse \u2192 upload to your compute environment \u2192 begin analysis. This approach gives you complete control over your computing environment and allows flexible tool installation, but requires more technical expertise to set up and manage.\n\nAdditional advantages of DRS-connected platforms include faster workflow setup (no waiting for downloads), reduced storage costs since data stays in Synapse until needed, better data provenance tracking, and automatic permission enforcement. They also provide collaborative workspaces and pre-built analysis environments.\n\nSelf-managed environments like institutional HPC offer high computational power, familiar environments for researchers, and are often better for large-scale workflows and custom pipeline development. However, they can be harder for external collaboration and reproduction, and access depends on your institution's specific resources and policies.\n\nThe choice between these approaches depends on your specific needs: DRS-connected platforms are ideal for collaborative projects and quick analysis setup, while self-managed compute is better for custom workflows, large-scale processing, and when you need complete control over the computing environment."
+    },
+    {
+      "question": "A contributor has been using the Data Curator App (DCA) to annotate a dataset and now wants to view and update that metadata using Synapse Curator. Is this supported, and under what condition?",
+      "persona": "CONTRIBUTOR",
+      "cross_page": false,
+      "expected_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/synapse-curator-transition-guide"
+      ],
+      "cited_urls": [
+        "https://help.nf.synapse.org/nf-data-portal-documentation/contributing-data/synapse-curator-transition-guide"
+      ],
+      "attribution_hit": true,
+      "correct_answer": "Yes - as long as a curation task has been set up for that dataset in Synapse Curator, DCA-annotated metadata can be viewed and updated there.",
+      "judge_score": 2,
+      "correct": true,
+      "agent_response": "Yes, viewing and updating metadata in Synapse Curator after using the Data Curator App (DCA) is supported. This scenario is expected and should present no issue. You can open any dataset that has already been annotated with the Data Curator App and view/update the metadata in Synapse Curator.\n\nThe condition for this compatibility is that a curation task must be set up for that dataset in Synapse Curator. If you don't immediately see a curation task for your dataset, you may need to reach out to the data management team to have Synapse Curator access set up for it. Currently, curation tasks are auto-setup based on what's mentioned in the original data sharing plan, and self-service task management UI is coming in a future update."
+    }
+  ],
+  "errors": []
+}

--- a/benchmark/kb-routing/README.md
+++ b/benchmark/kb-routing/README.md
@@ -11,7 +11,7 @@ The agent has two knowledge sources:
 | NF Help Docs KB | `DOCS` | Bedrock KB built from help.nf.synapse.org | `KNOWLEDGE_BASE` trace event or `WEB` citation |
 | NF-OSI Knowledge Graph | `GRAPH` | Structured RDF graph via SPARQL action groups | `ACTION_GROUP` trace event |
 
-This benchmark tests whether the agent routes queries to the right source — an issue the general-help eval cannot measure because it runs each question in isolation against a single-source agent.
+**This benchmark measures source routing, not answer correctness.** The primary metric is whether the agent consulted the right knowledge source — determined from Bedrock trace events — not whether the response text matches a gold answer. This is distinct from the general-help eval, which scores answer quality against known correct answers for a single-source agent. Answer quality is recorded here as a secondary metric only.
 
 ---
 
@@ -96,7 +96,18 @@ Add sessions directly to `kb_routing_dataset.json` following the schema in `kb_r
 
 ## Step 3: Evaluate
 
-`evaluate_kb_routing.py` invokes the agent, captures Bedrock trace events to detect which sources were used, and scores KB source selection accuracy alongside answer quality.
+`evaluate_kb_routing.py` invokes the agent and captures Bedrock trace events to determine which knowledge source was actually used. The primary output is KB source selection accuracy — whether the agent routed to the expected source — not whether the answer text is correct. Answer quality is scored as a secondary signal by an LLM judge.
+
+### Execution flow
+
+For each session the script:
+
+1. Creates a fresh Bedrock `sessionId` (UUID)
+2. Sends `turns` to the agent **in order**, reusing the same `sessionId` — so each turn arrives with the prior conversation in context
+3. After each turn, inspects trace events and response citations to detect which KB source was used (`DOCS`, `GRAPH`, both, or neither), then scores it against `expected_kb`
+4. Moves to the next turn in the same session before starting a new `sessionId` for the next session
+
+Single-turn sessions run this loop once. The `n_turns` field exists so sessions can be pre-filtered by turn count before running the eval (e.g. to isolate the effect of prior context on routing decisions).
 
 ### Requirements
 
@@ -146,14 +157,18 @@ The script enables `enableTrace=True` on agent invocations and inspects orchestr
 
 ### KB selection scoring
 
-| Score | Meaning |
-|-------|---------|
-| 2 | Correct — all expected sources used (extras acceptable); or `NONE` and no sources used |
-| 1 | Partial — some but not all expected sources used |
-| 0 | Wrong — used wrong/no source when one was expected; or used any source when `NONE` expected |
-| -1 | No trace detected (excluded from accuracy) |
+| Score | Meaning | `kb_correct` |
+|-------|---------|:---:|
+| 2 | Correct and efficient — used exactly the expected source(s); or `NONE` and no sources used | ✓ |
+| 1 | Correct but over-queried — used the right source plus unnecessary extras (`DOCS`/`GRAPH` turns only); or expected `BOTH` but only one source used | ✓ |
+| 0 | Wrong — used no source or wrong source when one was expected; or used any source when `NONE` expected | ✗ |
+| -1 | No trace detected (excluded from accuracy reporting) | — |
 
-### Answer quality scoring (LLM judge)
+`kb_correct` (`score >= 1`) captures whether the agent reached the right source at all. `score == 2` additionally captures routing efficiency — useful for identifying unnecessary KB calls on single-source questions.
+
+### Answer quality scoring (LLM judge, secondary)
+
+Unlike the general-help eval, there is no gold answer to compare against. The judge scores whether the response is coherent and on-topic given what type of source should have been used — not whether it matches a known correct answer.
 
 | Score | Meaning |
 |-------|---------|
@@ -175,9 +190,11 @@ Results are saved as `routing_eval_results_<timestamp>.json`. Each file contains
 
 | Metric | Description |
 |--------|-------------|
-| KB selection accuracy | % turns where correct source(s) used (score ≥ 2) |
-| Per-source accuracy | Accuracy broken down by DOCS / GRAPH / BOTH |
-| Actual usage distribution | What sources the agent actually used |
-| Answer quality | % turns scored 2 by the judge |
-| Per-persona KB accuracy | Accuracy by CONTRIBUTOR, REUSER, FUNDER, etc. |
-| Turn-1 vs turn-2+ accuracy | Whether prior session context affects routing |
+| KB routing accuracy | % turns with `kb_correct` (score ≥ 1) — agent reached the right source |
+| KB routing efficiency | % turns with score = 2 — right source used with no unnecessary extras |
+| Over-query rate | % `DOCS`/`GRAPH` turns with score = 1 — right source used but extras consulted |
+| Per-source breakdown | Above metrics broken down by `expected_kb` (DOCS / GRAPH / BOTH / NONE) |
+| Actual usage distribution | What source combinations the agent actually used |
+| Answer quality | % turns scored 2 by the LLM judge |
+| Per-persona KB accuracy | Routing accuracy by CONTRIBUTOR, REUSER, FUNDER, etc. |
+| Turn-1 vs turn-2+ accuracy | Whether prior session context affects routing decisions |

--- a/benchmark/kb-routing/README.md
+++ b/benchmark/kb-routing/README.md
@@ -69,12 +69,12 @@ The agent has two knowledge sources:
 
 | `session_type` | Sessions | Single-turn | Multi-turn | Turns |
 |----------------|----------|-------------|------------|-------|
-| DOCS | 5 | 3 | 2 | 8 |
+| DOCS | 4 | 2 | 2 | 6 |
 | GRAPH | 5 | 3 | 2 | 8 |
 | MIXED | 4 | — | 4 | 13 |
 | BOTH | 2 | 1 | 1 | 3 |
 | NONE | 3 | 2 | 1 | 4 |
-| **Total** | **19** | **9** | **10** | **36** |
+| **Total** | **18** | **8** | **10** | **34** |
 
 ---
 

--- a/benchmark/kb-routing/README.md
+++ b/benchmark/kb-routing/README.md
@@ -1,0 +1,175 @@
+# KB Routing Benchmark
+
+Evaluates whether the NF Portal multi-source Bedrock Agent selects the correct knowledge source for each query type. See [issue #36](https://github.com/nf-osi/portal-chatbot/issues/36).
+
+## Background
+
+The agent has two knowledge sources:
+
+| Source | Label | Description | Detection |
+|--------|-------|-------------|-----------|
+| NF Help Docs KB | `DOCS` | Bedrock KB built from help.nf.synapse.org | `KNOWLEDGE_BASE` trace event or `WEB` citation |
+| NF-OSI Knowledge Graph | `GRAPH` | Structured RDF graph via SPARQL action groups | `ACTION_GROUP` trace event |
+
+This benchmark tests whether the agent routes queries to the right source — an issue the general-help eval cannot measure because it runs each question in isolation against a single-source agent.
+
+---
+
+## Dataset
+
+`kb_routing_dataset.json` — a curated set of multi-turn sessions, each labeled with the expected KB source per turn.
+
+### Session structure
+
+```json
+{
+  "session_id": "s-mixed-01",
+  "description": "Contributor asks about process, then pivots to data inventory",
+  "n_turns": 2,
+  "turns": [
+    {
+      "id": "s-mixed-01-t1",
+      "question": "What is the data embargo policy?",
+      "expected_kb": "DOCS",
+      "persona": "CONTRIBUTOR",
+      "notes": "Policy question answered by documentation."
+    },
+    {
+      "id": "s-mixed-01-t2",
+      "question": "Show me all publicly available datasets",
+      "expected_kb": "GRAPH",
+      "persona": "REUSER",
+      "notes": "Data inventory requires querying the KG."
+    }
+  ]
+}
+```
+
+### `expected_kb` values
+
+| Value | Meaning |
+|-------|---------|
+| `DOCS` | Agent should use the documentation KB (process, policy, how-tos) |
+| `GRAPH` | Agent should use SPARQL action groups (counts, lists, specific records) |
+| `BOTH` | Either source is acceptable, or both should be used for a compound question |
+| `NONE` | No KB lookup expected — agent should answer from general knowledge or decline |
+
+### Session types in the seed dataset
+
+| Type | Sessions |
+|------|---------|
+| DOCS-only | 2 |
+| GRAPH-only | 2 |
+| Mixed (DOCS→GRAPH) | 1 |
+| Mixed (GRAPH→DOCS) | 1 |
+| Mixed (interleaved) | 1 |
+| BOTH (compound questions) | 1 |
+| Ambiguous edge cases | 1 |
+| NONE (off-topic / no KB needed) | 1 |
+| FUNDER overview (mixed) | 1 |
+
+---
+
+## Step 1: Expand the dataset
+
+Add sessions directly to `kb_routing_dataset.json` following the schema in `kb_routing_schema.json`. Each session requires a unique `session_id`, a `description`, `n_turns` (must equal the length of `turns`), and one or more turns with `id`, `question`, `expected_kb`, and `persona`.
+
+---
+
+## Step 2: Human validation
+
+- Verify each `expected_kb` label is accurate for the question.
+- Check that multi-turn sessions flow naturally (follow-up turns are coherent).
+- Flag questions where either source gives a valid answer (change `expected_kb` to `BOTH`); this includes both compound questions and genuinely ambiguous queries.
+- Ensure GRAPH questions can't be answered from docs alone.
+- Ensure DOCS questions don't require live KG data.
+
+---
+
+## Step 3: Evaluate
+
+`evaluate_kb_routing.py` invokes the agent, captures Bedrock trace events to detect which sources were used, and scores KB source selection accuracy alongside answer quality.
+
+### Requirements
+
+```bash
+pip install boto3 pandas
+```
+
+AWS credentials with access to the Bedrock Agent and Bedrock Runtime.
+
+### Run
+
+```bash
+cd benchmark/kb-routing
+python evaluate_kb_routing.py
+```
+
+Override defaults as needed:
+
+```bash
+python evaluate_kb_routing.py \
+  --agent-id WU3QRWA0FQ \
+  --alias-id TSTALIASID \
+  --profile default \
+  --region us-east-1 \
+  --dataset kb_routing_dataset.json \
+  --output routing_eval_results.json
+  # --judge-model to override LLM judge (defaults to Haiku 4.5)
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--agent-id` | `WU3QRWA0FQ` | Bedrock Agent ID |
+| `--alias-id` | `TSTALIASID` | Bedrock Agent alias ID |
+| `--profile` | `default` | AWS profile |
+| `--region` | `us-east-1` | AWS region |
+| `--dataset` | `kb_routing_dataset.json` | Sessions dataset |
+| `--judge-model` | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | Answer quality judge |
+| `--output` | `routing_eval_results.json` | Base output path (datestamp appended) |
+
+### Detection method
+
+The script enables `enableTrace=True` on agent invocations and inspects orchestration trace events:
+
+- `invocationType: "KNOWLEDGE_BASE"` or `type: "KNOWLEDGE_BASE"` → `DOCS` used
+- `invocationType: "ACTION_GROUP"` or `type: "ACTION_GROUP"` → `GRAPH` used
+- `WEB`-type citation in response chunk → also marks `DOCS`
+
+### KB selection scoring
+
+| Score | Meaning |
+|-------|---------|
+| 2 | Correct — all expected sources used (extras acceptable); or `NONE` and no sources used |
+| 1 | Partial — some but not all expected sources used |
+| 0 | Wrong — used wrong/no source when one was expected; or used any source when `NONE` expected |
+| -1 | No trace detected (excluded from accuracy) |
+
+### Answer quality scoring (LLM judge)
+
+| Score | Meaning |
+|-------|---------|
+| 2 | Clear, on-topic, informative answer |
+| 1 | Partial or vague |
+| 0 | Off-topic, evasive, or error |
+| -1 | Judge failure |
+
+### Output
+
+Results are saved as `routing_eval_results_<timestamp>.json`. Each file contains:
+
+- `timestamp` — UTC timestamp
+- `config` — agent ID, alias, judge model, dataset
+- `results` — per-turn scores including `kb_used`, `kb_score`, `kb_correct`, `answer_score`
+- `errors` — failed turns
+
+### Metrics printed
+
+| Metric | Description |
+|--------|-------------|
+| KB selection accuracy | % turns where correct source(s) used (score ≥ 2) |
+| Per-source accuracy | Accuracy broken down by DOCS / GRAPH / BOTH |
+| Actual usage distribution | What sources the agent actually used |
+| Answer quality | % turns scored 2 by the judge |
+| Per-persona KB accuracy | Accuracy by CONTRIBUTOR, REUSER, FUNDER, etc. |
+| Turn-1 vs turn-2+ accuracy | Whether prior session context affects routing |

--- a/benchmark/kb-routing/README.md
+++ b/benchmark/kb-routing/README.md
@@ -24,6 +24,7 @@ This benchmark tests whether the agent routes queries to the right source — an
 ```json
 {
   "session_id": "s-mixed-01",
+  "session_type": "MIXED",
   "description": "Contributor asks about process, then pivots to data inventory",
   "n_turns": 2,
   "turns": [
@@ -54,25 +55,32 @@ This benchmark tests whether the agent routes queries to the right source — an
 | `BOTH` | Either source is acceptable, or both should be used for a compound question |
 | `NONE` | No KB lookup expected — agent should answer from general knowledge or decline |
 
-### Session types in the seed dataset
+### `session_type` values
 
-| Type | Sessions |
-|------|---------|
-| DOCS-only | 2 |
-| GRAPH-only | 2 |
-| Mixed (DOCS→GRAPH) | 1 |
-| Mixed (GRAPH→DOCS) | 1 |
-| Mixed (interleaved) | 1 |
-| BOTH (compound questions) | 1 |
-| Ambiguous edge cases | 1 |
-| NONE (off-topic / no KB needed) | 1 |
-| FUNDER overview (mixed) | 1 |
+| Value | Meaning |
+|-------|---------|
+| `DOCS` | All turns expect the documentation KB |
+| `GRAPH` | All turns expect the KG / SPARQL action groups |
+| `MIXED` | Turns route to different sources within the same session |
+| `BOTH` | All turns accept either or both sources (compound or ambiguous questions) |
+| `NONE` | No KB lookup expected for any turn |
+
+### Dataset composition
+
+| `session_type` | Sessions | Single-turn | Multi-turn | Turns |
+|----------------|----------|-------------|------------|-------|
+| DOCS | 5 | 3 | 2 | 8 |
+| GRAPH | 5 | 3 | 2 | 8 |
+| MIXED | 4 | — | 4 | 13 |
+| BOTH | 2 | 1 | 1 | 3 |
+| NONE | 3 | 2 | 1 | 4 |
+| **Total** | **19** | **9** | **10** | **36** |
 
 ---
 
 ## Step 1: Expand the dataset
 
-Add sessions directly to `kb_routing_dataset.json` following the schema in `kb_routing_schema.json`. Each session requires a unique `session_id`, a `description`, `n_turns` (must equal the length of `turns`), and one or more turns with `id`, `question`, `expected_kb`, and `persona`.
+Add sessions directly to `kb_routing_dataset.json` following the schema in `kb_routing_schema.json`. Each session requires `session_id`, `session_type`, `description`, `n_turns` (must equal the length of `turns`), and turns with `id`, `question`, `expected_kb`, and `persona`.
 
 ---
 

--- a/benchmark/kb-routing/evaluate_kb_routing.py
+++ b/benchmark/kb-routing/evaluate_kb_routing.py
@@ -98,13 +98,16 @@ def invoke_agent(
 # ---------------------------------------------------------------------------
 
 def score_kb_selection(expected_kb: str, kb_sources_used: set[str]) -> dict:
-    """Score whether the agent used the expected KB source(s).
+    """Score whether the agent used the expected KB source(s) efficiently.
 
     Scoring:
-      2 — correct: all expected sources used (extras acceptable); or NONE and no sources used
-      1 — partial: expected BOTH but only one source used
-      0 — wrong: used a source when NONE expected, or used wrong/no source when one was expected
+      2 — correct and efficient: used exactly the expected source(s); or NONE and no sources used
+      1 — correct but over-queried: used the expected source plus unnecessary extras
+          (only applies to DOCS/GRAPH turns; BOTH turns are never penalised for extra sources)
+      0 — wrong: used wrong/no source when one was expected; or used any source when NONE expected
      -1 — no trace detected (excluded from accuracy reporting)
+
+    kb_correct is True for score >= 1 (agent reached the right source regardless of efficiency).
 
     Returns dict with kb_used, kb_score, kb_correct.
     """
@@ -128,23 +131,24 @@ def score_kb_selection(expected_kb: str, kb_sources_used: set[str]) -> dict:
 
     correct_used = expected & kb_sources_used
 
-    if expected.issubset(kb_sources_used):
-        # All expected sources present (may have used extras)
+    if kb_sources_used == expected:
+        # Exactly the right source(s) — correct and efficient
         kb_score = 2
-        kb_correct = True
+    elif expected.issubset(kb_sources_used):
+        # Right source used but unnecessary extras consulted
+        # BOTH already expects any/both, so extras are only penalised for DOCS/GRAPH
+        kb_score = 1 if expected_kb in ("DOCS", "GRAPH") else 2
     elif correct_used:
-        # Partial: some expected sources used
+        # Some expected sources used but not all (only reachable for BOTH)
         kb_score = 1
-        kb_correct = False
     else:
         # None of the expected sources used
         kb_score = 0
-        kb_correct = False
 
     return {
         "kb_used": sorted(kb_sources_used),
         "kb_score": kb_score,
-        "kb_correct": kb_correct,
+        "kb_correct": kb_score >= 1,
     }
 
 
@@ -254,31 +258,38 @@ def print_metrics(results: list[dict]) -> None:
     print(f"KB ROUTING EVALUATION RESULTS  ({n} turns across {df['session_id'].nunique()} sessions)")
     print(f"{'='*60}")
 
-    # --- KB source selection accuracy ---
-    # Exclude turns where kb_score is None (no expected_kb set) or -1 (no trace)
+    # --- KB routing accuracy and efficiency ---
+    # Exclude turns with no trace (-1); those are uninformative
     kb_df = df[df["kb_score"].notna() & (df["kb_score"] != -1)]
+    no_trace = (df["kb_score"] == -1).sum()
     if len(kb_df) > 0:
-        kb_acc = kb_df["kb_correct"].mean()
-        kb_full = (kb_df["kb_score"] == 2).mean()
-        kb_partial = (kb_df["kb_score"] == 1).mean()
-        kb_wrong = (kb_df["kb_score"] == 0).mean()
-        no_trace = (df["kb_score"] == -1).sum()
-        print(f"\nKB source selection accuracy: {kb_acc:.1%}  ({kb_df['kb_correct'].sum():.0f} / {len(kb_df)})")
-        print(f"  Full credit (score=2): {kb_full:.1%}")
-        print(f"  Partial    (score=1): {kb_partial:.1%}")
-        print(f"  Wrong      (score=0): {kb_wrong:.1%}")
-        if no_trace > 0:
-            print(f"  No trace detected:    {no_trace} turns (excluded from accuracy)")
-    else:
-        print("\nKB source selection: no scorable turns")
+        n_kb = len(kb_df)
+        routing_acc = kb_df["kb_correct"].mean()           # score >= 1: right source reached
+        efficiency  = (kb_df["kb_score"] == 2).mean()     # score == 2: right source, no extras
+        over_query_df = kb_df[kb_df["expected_kb"].isin(["DOCS", "GRAPH"])]
+        over_query = (over_query_df["kb_score"] == 1).mean() if len(over_query_df) else float("nan")
+        wrong = (kb_df["kb_score"] == 0).mean()
 
-    # --- Per expected_kb accuracy ---
-    print("\nKB selection accuracy by expected source:")
-    for kb_type in ["DOCS", "GRAPH", "BOTH"]:
-        sub = kb_df[kb_df["expected_kb"] == kb_type]
-        if len(sub) > 0:
+        print(f"\nKB routing accuracy  (score ≥ 1): {routing_acc:.1%}  ({kb_df['kb_correct'].sum():.0f} / {n_kb})")
+        print(f"KB routing efficiency (score = 2): {efficiency:.1%}  — right source, no unnecessary extras")
+        print(f"Over-query rate       (score = 1): {over_query:.1%}  — right source + extras  (DOCS/GRAPH turns only, n={len(over_query_df)})")
+        print(f"Wrong source          (score = 0): {wrong:.1%}")
+        if no_trace > 0:
+            print(f"No trace detected:                 {no_trace} turns (excluded)")
+    else:
+        print("\nKB routing: no scorable turns")
+
+    # --- Per expected_kb breakdown ---
+    if len(kb_df) > 0:
+        print("\nPer-source breakdown:")
+        print(f"  {'Source':<6}  {'Accuracy':>8}  {'Efficiency':>10}  {'n':>4}")
+        for kb_type in ["DOCS", "GRAPH", "BOTH", "NONE"]:
+            sub = kb_df[kb_df["expected_kb"] == kb_type]
+            if len(sub) == 0:
+                continue
             acc = sub["kb_correct"].mean()
-            print(f"  {kb_type:<6} {acc:.1%}  ({sub['kb_correct'].sum():.0f} / {len(sub)})")
+            eff = (sub["kb_score"] == 2).mean()
+            print(f"  {kb_type:<6}  {acc:>8.1%}  {eff:>10.1%}  {len(sub):>4}")
 
     # --- What source was actually used vs expected ---
     print("\nActual KB usage distribution:")
@@ -296,9 +307,9 @@ def print_metrics(results: list[dict]) -> None:
         score_dist.index = score_dist.index.map(score_map)
         print(f"  Distribution:\n{score_dist.to_string()}")
 
-    # --- Per-persona KB accuracy ---
+    # --- Per-persona routing accuracy ---
     if len(kb_df) > 0:
-        print("\nKB selection accuracy by persona:")
+        print("\nRouting accuracy by persona:")
         persona_acc = (
             kb_df.groupby("persona")["kb_correct"]
             .agg(accuracy="mean", n="count")
@@ -308,14 +319,14 @@ def print_metrics(results: list[dict]) -> None:
         persona_acc["accuracy"] = persona_acc["accuracy"].map("{:.1%}".format)
         print(persona_acc.to_string(index=False))
 
-    # --- Single-turn vs multi-turn accuracy ---
+    # --- Single-turn vs multi-turn routing accuracy ---
     if len(kb_df) > 0:
         single = kb_df[kb_df["turn_number"] == 1]["kb_correct"].mean()
         multi = kb_df[kb_df["turn_number"] > 1]["kb_correct"].mean()
         n_single = (kb_df["turn_number"] == 1).sum()
         n_multi = (kb_df["turn_number"] > 1).sum()
-        print(f"\nKB accuracy — turn 1 (no prior context): {single:.1%}  (n={n_single})")
-        print(f"KB accuracy — turn 2+ (with prior context): {multi:.1%}  (n={n_multi})")
+        print(f"\nRouting accuracy — turn 1 (no prior context): {single:.1%}  (n={n_single})")
+        print(f"Routing accuracy — turn 2+ (with prior context): {multi:.1%}  (n={n_multi})")
 
     print(f"\n{'='*60}")
 

--- a/benchmark/kb-routing/evaluate_kb_routing.py
+++ b/benchmark/kb-routing/evaluate_kb_routing.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""Evaluate KB source routing for the NF Portal multi-source Bedrock Agent.
+
+Invokes the agent with each turn in each session (reusing session IDs across
+turns), captures Bedrock trace events to detect which KB source was used
+(DOCS knowledge base vs. GRAPH action groups), and reports KB source selection
+accuracy alongside answer quality metrics.
+
+Usage:
+    python evaluate_kb_routing.py
+    python evaluate_kb_routing.py --agent-id WU3QRWA0FQ --alias-id TSTALIASID
+    python evaluate_kb_routing.py --dataset kb_routing_dataset.json --profile my-profile
+
+Detection logic:
+    DOCS:  KNOWLEDGE_BASE invocation in trace (or WEB-type citation in response chunk)
+    GRAPH: ACTION_GROUP invocation in trace (SPARQL Lambda calls)
+"""
+
+import argparse
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import boto3
+import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# Agent invocation with trace
+# ---------------------------------------------------------------------------
+
+def invoke_agent(
+    agent_client,
+    agent_id: str,
+    agent_alias_id: str,
+    question: str,
+    session_id: str,
+) -> tuple[str, list[str], set[str]]:
+    """Invoke agent and return (response_text, cited_urls, kb_sources_used).
+
+    kb_sources_used is a set of "DOCS" and/or "GRAPH" detected from trace events
+    and response chunk citations.
+    """
+    response = agent_client.invoke_agent(
+        agentId=agent_id,
+        agentAliasId=agent_alias_id,
+        sessionId=session_id,
+        inputText=question,
+        enableTrace=True,
+    )
+
+    completion = ""
+    cited_urls: list[str] = []
+    kb_sources_used: set[str] = set()
+
+    for event in response["completion"]:
+        # Response text and WEB citations
+        if "chunk" in event:
+            chunk = event["chunk"]
+            completion += chunk["bytes"].decode("utf-8")
+            for citation in chunk.get("attribution", {}).get("citations", []):
+                for ref in citation.get("retrievedReferences", []):
+                    location = ref.get("location", {})
+                    if location.get("type") == "WEB":
+                        url = location.get("webLocation", {}).get("url")
+                        if url and url not in cited_urls:
+                            cited_urls.append(url)
+                        kb_sources_used.add("DOCS")
+
+        # Trace events for orchestration steps
+        if "trace" in event:
+            trace_data = event["trace"].get("trace", {})
+            orch = trace_data.get("orchestrationTrace", {})
+
+            # Detect via invocationInput (pre-call)
+            inv_input = orch.get("invocationInput", {})
+            inv_type = inv_input.get("invocationType", "")
+            if inv_type == "ACTION_GROUP":
+                kb_sources_used.add("GRAPH")
+            elif inv_type == "KNOWLEDGE_BASE":
+                kb_sources_used.add("DOCS")
+
+            # Detect via observation (post-call confirmation)
+            obs = orch.get("observation", {})
+            obs_type = obs.get("type", "")
+            if obs_type == "ACTION_GROUP":
+                kb_sources_used.add("GRAPH")
+            elif obs_type == "KNOWLEDGE_BASE":
+                kb_sources_used.add("DOCS")
+
+    return completion.strip(), cited_urls, kb_sources_used
+
+
+# ---------------------------------------------------------------------------
+# KB source selection scoring
+# ---------------------------------------------------------------------------
+
+def score_kb_selection(expected_kb: str, kb_sources_used: set[str]) -> dict:
+    """Score whether the agent used the expected KB source(s).
+
+    Scoring:
+      2 — correct: all expected sources used (extras acceptable); or NONE and no sources used
+      1 — partial: expected BOTH but only one source used
+      0 — wrong: used a source when NONE expected, or used wrong/no source when one was expected
+     -1 — no trace detected (excluded from accuracy reporting)
+
+    Returns dict with kb_used, kb_score, kb_correct.
+    """
+    if expected_kb == "DOCS":
+        expected = {"DOCS"}
+    elif expected_kb == "GRAPH":
+        expected = {"GRAPH"}
+    elif expected_kb == "BOTH":
+        expected = {"DOCS", "GRAPH"}
+    elif expected_kb == "NONE":
+        expected = set()
+        if not kb_sources_used:
+            return {"kb_used": [], "kb_score": 2, "kb_correct": True}
+        else:
+            return {"kb_used": sorted(kb_sources_used), "kb_score": 0, "kb_correct": False}
+    else:
+        expected = set()
+
+    if not kb_sources_used:
+        return {"kb_used": [], "kb_score": -1, "kb_correct": False}
+
+    correct_used = expected & kb_sources_used
+
+    if expected.issubset(kb_sources_used):
+        # All expected sources present (may have used extras)
+        kb_score = 2
+        kb_correct = True
+    elif correct_used:
+        # Partial: some expected sources used
+        kb_score = 1
+        kb_correct = False
+    else:
+        # None of the expected sources used
+        kb_score = 0
+        kb_correct = False
+
+    return {
+        "kb_used": sorted(kb_sources_used),
+        "kb_score": kb_score,
+        "kb_correct": kb_correct,
+    }
+
+
+# ---------------------------------------------------------------------------
+# LLM judge for answer quality
+# ---------------------------------------------------------------------------
+
+def judge_answer(
+    bedrock_client,
+    judge_model_id: str,
+    question: str,
+    agent_response: str,
+    expected_kb: str,
+) -> int:
+    """Score answer quality without a gold answer.
+
+    Judges whether the response is a coherent, helpful answer to the question
+    given what type of source should have been used.
+
+    Returns:
+      2 — clear, on-topic, informative answer
+      1 — partial or vague answer
+      0 — off-topic, evasive, or error response
+     -1 — judge failure
+    """
+    source_hint = {
+        "DOCS": "documentation/process/policy information",
+        "GRAPH": "specific data counts, lists, or records from the NF portal knowledge graph",
+        "BOTH": "a combination of documentation guidance and specific portal data",
+    }.get(expected_kb, "relevant information")
+
+    prompt = (
+        "You are evaluating an AI assistant's response for the NF Data Portal.\n\n"
+        f"User question: {question}\n\n"
+        f"Expected answer type: {source_hint}\n\n"
+        f"Assistant's response: {agent_response}\n\n"
+        "Score whether the response is a coherent, helpful answer to the question:\n"
+        "  2 — clear and informative; directly addresses what was asked\n"
+        "  1 — partially answers the question; vague or incomplete\n"
+        "  0 — off-topic, evasive, states it cannot answer, or is an error\n\n"
+        "Reply with a single digit (0, 1, or 2) and nothing else."
+    )
+
+    body = json.dumps({
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 8,
+        "messages": [{"role": "user", "content": prompt}],
+    })
+    resp = bedrock_client.invoke_model(modelId=judge_model_id, body=body)
+    digit = json.loads(resp["body"].read())["content"][0]["text"].strip()
+    return int(digit) if digit in ("0", "1", "2") else -1
+
+
+# ---------------------------------------------------------------------------
+# Per-turn evaluation
+# ---------------------------------------------------------------------------
+
+def evaluate_turn(
+    agent_client,
+    bedrock_client,
+    agent_id: str,
+    agent_alias_id: str,
+    judge_model_id: str,
+    session_id: str,
+    turn: dict,
+    turn_number: int,
+) -> dict:
+    """Evaluate a single turn within a session."""
+    question = turn["question"]
+    expected_kb = turn["expected_kb"]
+    persona = turn["persona"]
+
+    agent_response, cited_urls, kb_sources_used = invoke_agent(
+        agent_client, agent_id, agent_alias_id, question, session_id
+    )
+
+    kb_result = score_kb_selection(expected_kb, kb_sources_used)
+    answer_score = judge_answer(bedrock_client, judge_model_id, question, agent_response, expected_kb)
+
+    return {
+        "session_id": session_id,
+        "turn_id": turn["id"],
+        "turn_number": turn_number,
+        "question": question,
+        "persona": persona,
+        "expected_kb": expected_kb,
+        "kb_used": kb_result["kb_used"],
+        "kb_score": kb_result["kb_score"],
+        "kb_correct": kb_result["kb_correct"],
+        "cited_urls": cited_urls,
+        "answer_score": answer_score,
+        "answer_correct": answer_score == 2,
+        "agent_response": agent_response,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Metrics reporting
+# ---------------------------------------------------------------------------
+
+def print_metrics(results: list[dict]) -> None:
+    """Print KB routing evaluation metrics to stdout."""
+    df = pd.DataFrame(results)
+
+    n = len(df)
+    print(f"\n{'='*60}")
+    print(f"KB ROUTING EVALUATION RESULTS  ({n} turns across {df['session_id'].nunique()} sessions)")
+    print(f"{'='*60}")
+
+    # --- KB source selection accuracy ---
+    # Exclude turns where kb_score is None (no expected_kb set) or -1 (no trace)
+    kb_df = df[df["kb_score"].notna() & (df["kb_score"] != -1)]
+    if len(kb_df) > 0:
+        kb_acc = kb_df["kb_correct"].mean()
+        kb_full = (kb_df["kb_score"] == 2).mean()
+        kb_partial = (kb_df["kb_score"] == 1).mean()
+        kb_wrong = (kb_df["kb_score"] == 0).mean()
+        no_trace = (df["kb_score"] == -1).sum()
+        print(f"\nKB source selection accuracy: {kb_acc:.1%}  ({kb_df['kb_correct'].sum():.0f} / {len(kb_df)})")
+        print(f"  Full credit (score=2): {kb_full:.1%}")
+        print(f"  Partial    (score=1): {kb_partial:.1%}")
+        print(f"  Wrong      (score=0): {kb_wrong:.1%}")
+        if no_trace > 0:
+            print(f"  No trace detected:    {no_trace} turns (excluded from accuracy)")
+    else:
+        print("\nKB source selection: no scorable turns")
+
+    # --- Per expected_kb accuracy ---
+    print("\nKB selection accuracy by expected source:")
+    for kb_type in ["DOCS", "GRAPH", "BOTH"]:
+        sub = kb_df[kb_df["expected_kb"] == kb_type]
+        if len(sub) > 0:
+            acc = sub["kb_correct"].mean()
+            print(f"  {kb_type:<6} {acc:.1%}  ({sub['kb_correct'].sum():.0f} / {len(sub)})")
+
+    # --- What source was actually used vs expected ---
+    print("\nActual KB usage distribution:")
+    used_counts = pd.Series([str(sorted(r["kb_used"])) for r in results]).value_counts()
+    for label, count in used_counts.items():
+        print(f"  {label}: {count}")
+
+    # --- Answer quality ---
+    ans_df = df[df["answer_score"] != -1]
+    if len(ans_df) > 0:
+        ans_acc = (ans_df["answer_score"] == 2).mean()
+        print(f"\nAnswer quality (judge score=2): {ans_acc:.1%}  ({(ans_df['answer_score']==2).sum()} / {len(ans_df)})")
+        score_map = {-1: "judge failed", 0: "off-topic/error", 1: "partial", 2: "correct"}
+        score_dist = df["answer_score"].value_counts().sort_index()
+        score_dist.index = score_dist.index.map(score_map)
+        print(f"  Distribution:\n{score_dist.to_string()}")
+
+    # --- Per-persona KB accuracy ---
+    if len(kb_df) > 0:
+        print("\nKB selection accuracy by persona:")
+        persona_acc = (
+            kb_df.groupby("persona")["kb_correct"]
+            .agg(accuracy="mean", n="count")
+            .sort_values("accuracy", ascending=False)
+            .reset_index()
+        )
+        persona_acc["accuracy"] = persona_acc["accuracy"].map("{:.1%}".format)
+        print(persona_acc.to_string(index=False))
+
+    # --- Single-turn vs multi-turn accuracy ---
+    if len(kb_df) > 0:
+        single = kb_df[kb_df["turn_number"] == 1]["kb_correct"].mean()
+        multi = kb_df[kb_df["turn_number"] > 1]["kb_correct"].mean()
+        n_single = (kb_df["turn_number"] == 1).sum()
+        n_multi = (kb_df["turn_number"] > 1).sum()
+        print(f"\nKB accuracy — turn 1 (no prior context): {single:.1%}  (n={n_single})")
+        print(f"KB accuracy — turn 2+ (with prior context): {multi:.1%}  (n={n_multi})")
+
+    print(f"\n{'='*60}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def run_evaluation(args: argparse.Namespace) -> None:
+    """Run the full KB routing evaluation pipeline."""
+    session = boto3.Session(profile_name=args.profile, region_name=args.region)
+    agent_client = session.client("bedrock-agent-runtime")
+    bedrock_client = session.client("bedrock-runtime")
+
+    sts = session.client("sts")
+    identity = sts.get_caller_identity()
+    print(f"Authenticated as: {identity['Arn']}")
+    print(f"Region: {args.region}")
+
+    dataset_path = Path(args.dataset)
+    with open(dataset_path) as f:
+        dataset = json.load(f)
+
+    total_turns = sum(len(s["turns"]) for s in dataset)
+    print(f"Loaded {len(dataset)} sessions ({total_turns} turns) from {dataset_path.name}")
+
+    results: list[dict] = []
+    errors: list[dict] = []
+
+    for si, session_data in enumerate(dataset, 1):
+        # Each session uses a fresh Bedrock session so prior turns are in context
+        bedrock_session_id = str(uuid.uuid4())
+        n_turns = len(session_data["turns"])
+        print(f"\n[Session {si}/{len(dataset)}] {session_data['description']!r}  ({n_turns} turns)")
+
+        for ti, turn in enumerate(session_data["turns"], 1):
+            label = f"  Turn {ti}/{n_turns}: [{turn['expected_kb']}] {turn['question'][:65]}..."
+            print(label, flush=True)
+            try:
+                result = evaluate_turn(
+                    agent_client,
+                    bedrock_client,
+                    args.agent_id,
+                    args.alias_id,
+                    args.judge_model,
+                    bedrock_session_id,
+                    turn,
+                    ti,
+                )
+                results.append(result)
+                kb_status = "OK" if result["kb_correct"] else f"WRONG (used {result['kb_used']})"
+                print(f"    KB: {kb_status}  |  Answer score: {result['answer_score']}")
+            except Exception as e:
+                errors.append({
+                    "session_id": session_data["session_id"],
+                    "turn_id": turn["id"],
+                    "error": str(e),
+                })
+                print(f"    ERROR: {e}")
+
+    print(f"\nCompleted: {len(results)} turns scored, {len(errors)} errors")
+
+    # Save results
+    output_path = Path(args.output)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    dated_path = output_path.with_name(f"{output_path.stem}_{timestamp}{output_path.suffix}")
+
+    payload = {
+        "timestamp": timestamp,
+        "config": {
+            "agent_id": args.agent_id,
+            "agent_alias_id": args.alias_id,
+            "judge_model": args.judge_model,
+            "dataset": str(dataset_path),
+        },
+        "results": results,
+        "errors": errors,
+    }
+
+    dated_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(dated_path, "w") as f:
+        json.dump(payload, f, indent=2)
+    print(f"Results saved to {dated_path}")
+
+    if results:
+        print_metrics(results)
+    else:
+        print("No results to report.")
+
+    if errors:
+        sys.exit(1)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate KB source routing for the NF Portal multi-source Bedrock Agent.",
+    )
+    parser.add_argument(
+        "--agent-id",
+        default="WU3QRWA0FQ",
+        help="Bedrock Agent ID (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--alias-id",
+        default="TSTALIASID",
+        help="Bedrock Agent alias ID (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--profile",
+        default="default",
+        help="AWS profile name (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--region",
+        default="us-east-1",
+        help="AWS region (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--dataset",
+        default="kb_routing_dataset.json",
+        help="Path to the routing sessions dataset JSON (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--output",
+        default="routing_eval_results.json",
+        help="Base output path; a UTC datestamp is appended (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--judge-model",
+        default="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        help="Bedrock model ID for the LLM judge (default: %(default)s)",
+    )
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    run_evaluation(parse_args())

--- a/benchmark/kb-routing/kb_routing_dataset.json
+++ b/benchmark/kb-routing/kb_routing_dataset.json
@@ -1,8 +1,129 @@
 [
   {
+    "session_id": "s-docs-single-01",
+    "session_type": "DOCS",
+    "description": "How long is the standard data embargo period",
+    "n_turns": 1,
+    "turns": [
+      {
+        "id": "s-docs-single-01-t1",
+        "question": "How long is the standard data embargo period on the NF portal?",
+        "expected_kb": "DOCS",
+        "persona": "CONTRIBUTOR",
+        "notes": "Embargo policy is defined in documentation."
+      }
+    ]
+  },
+  {
+    "session_id": "s-docs-single-02",
+    "session_type": "DOCS",
+    "description": "Requirements for submitting human data",
+    "n_turns": 1,
+    "turns": [
+      {
+        "id": "s-docs-single-02-t1",
+        "question": "What consent and IRB documentation is required when submitting human data?",
+        "expected_kb": "DOCS",
+        "persona": "CONTRIBUTOR",
+        "notes": "Regulatory submission requirements are covered in the help docs."
+      }
+    ]
+  },
+  {
+    "session_id": "s-docs-single-03",
+    "session_type": "DOCS",
+    "description": "How to download data using the Synapse client",
+    "n_turns": 1,
+    "turns": [
+      {
+        "id": "s-docs-single-03-t1",
+        "question": "How do I download files from the NF portal using the Synapse Python client?",
+        "expected_kb": "DOCS",
+        "persona": "REUSER",
+        "notes": "Download instructions via the Synapse client are in the help docs."
+      }
+    ]
+  },
+  {
+    "session_id": "s-graph-single-01",
+    "session_type": "GRAPH",
+    "description": "Count of biobanks on the portal",
+    "n_turns": 1,
+    "turns": [
+      {
+        "id": "s-graph-single-01-t1",
+        "question": "How many biobanks are listed on the NF portal?",
+        "expected_kb": "GRAPH",
+        "persona": "REUSER",
+        "notes": "Current count requires querying the KG; docs won't have live numbers."
+      }
+    ]
+  },
+  {
+    "session_id": "s-graph-single-02",
+    "session_type": "GRAPH",
+    "description": "Animal model tools for NF2",
+    "n_turns": 1,
+    "turns": [
+      {
+        "id": "s-graph-single-02-t1",
+        "question": "List the animal model tools available for NF2 research",
+        "expected_kb": "GRAPH",
+        "persona": "REUSER",
+        "notes": "Listing specific resources requires a SPARQL query over the KG."
+      }
+    ]
+  },
+  {
+    "session_id": "s-graph-single-03",
+    "session_type": "GRAPH",
+    "description": "Study with the most associated files",
+    "n_turns": 1,
+    "turns": [
+      {
+        "id": "s-graph-single-03-t1",
+        "question": "Which study on the portal has the most associated data files?",
+        "expected_kb": "GRAPH",
+        "persona": "FUNDER",
+        "notes": "Ranking studies by file count requires aggregating over the KG."
+      }
+    ]
+  },
+  {
+    "session_id": "s-none-single-01",
+    "session_type": "NONE",
+    "description": "General programming question unrelated to the portal",
+    "n_turns": 1,
+    "turns": [
+      {
+        "id": "s-none-single-01-t1",
+        "question": "Help me write a Python script to reverse a string",
+        "expected_kb": "NONE",
+        "persona": "X",
+        "notes": "General coding question; no portal KB needed. Assistant should ideally decline this question."
+      }
+    ]
+  },
+  {
+    "session_id": "s-none-single-02",
+    "session_type": "NONE",
+    "description": "General background question about neurofibromatosis",
+    "n_turns": 1,
+    "turns": [
+      {
+        "id": "s-none-single-02-t1",
+        "question": "hi, is neurofibromatosis a cancer or autoimmune disease?",
+        "expected_kb": "NONE",
+        "persona": "X",
+        "notes": "General medical background answerable from model knowledge; no portal KB needed."
+      }
+    ]
+  },
+  {
     "session_id": "s-docs-01",
-    "description": "DOCS-only: data contribution process for a new contributor",
-    "n_turns": 3,
+    "session_type": "DOCS",
+    "description": "Data contribution process for a new contributor",
+    "n_turns": 2,
     "turns": [
       {
         "id": "s-docs-01-t1",
@@ -17,19 +138,13 @@
         "expected_kb": "DOCS",
         "persona": "CONTRIBUTOR",
         "notes": "Metadata requirements are documented; cannot be answered by querying the graph."
-      },
-      {
-        "id": "s-docs-01-t3",
-        "question": "What happens after my data passes quality control?",
-        "expected_kb": "DOCS",
-        "persona": "CONTRIBUTOR",
-        "notes": "Post-QC process (release, embargo lifting) is described in the help docs."
       }
     ]
   },
   {
     "session_id": "s-docs-02",
-    "description": "DOCS-only: data access and licensing questions from a reuser",
+    "session_type": "DOCS",
+    "description": "Data access and licensing questions from a reuser",
     "n_turns": 3,
     "turns": [
       {
@@ -57,7 +172,8 @@
   },
   {
     "session_id": "s-graph-01",
-    "description": "GRAPH-only: exploring available NF1 cell line tools",
+    "session_type": "GRAPH",
+    "description": "Exploring available NF1 cell line tools",
     "n_turns": 3,
     "turns": [
       {
@@ -85,8 +201,9 @@
   },
   {
     "session_id": "s-graph-02",
-    "description": "GRAPH-only: dataset discovery and publication search",
-    "n_turns": 3,
+    "session_type": "GRAPH",
+    "description": "Dataset discovery and publication search",
+    "n_turns": 2,
     "turns": [
       {
         "id": "s-graph-02-t1",
@@ -101,20 +218,14 @@
         "expected_kb": "GRAPH",
         "persona": "REUSER",
         "notes": "Dataset listing by data type and disease; requires SPARQL over KG."
-      },
-      {
-        "id": "s-graph-02-t3",
-        "question": "Find publications about MPNST from the last five years",
-        "expected_kb": "GRAPH",
-        "persona": "REUSER",
-        "notes": "Publication search is a graph/text query task; docs won't list specific papers."
       }
     ]
   },
   {
     "session_id": "s-mixed-docs-then-graph",
-    "description": "Mixed: contributor asks about process, then pivots to portal data inventory",
-    "n_turns": 3,
+    "session_type": "MIXED",
+    "description": "Contributor asks about embargo policy, then pivots to data inventory",
+    "n_turns": 2,
     "turns": [
       {
         "id": "s-mixed-01-t1",
@@ -129,24 +240,18 @@
         "expected_kb": "GRAPH",
         "persona": "REUSER",
         "notes": "Pivot to actual data inventory; requires querying the KG."
-      },
-      {
-        "id": "s-mixed-01-t3",
-        "question": "How many of those are RNA-seq?",
-        "expected_kb": "GRAPH",
-        "persona": "REUSER",
-        "notes": "Follow-up count; still a graph query. Context-dependent turn."
       }
     ]
   },
   {
     "session_id": "s-mixed-graph-then-docs",
-    "description": "Mixed: researcher explores data first, then asks how to contribute",
+    "session_type": "MIXED",
+    "description": "Researcher explores data, then asks how to contribute",
     "n_turns": 3,
     "turns": [
       {
         "id": "s-mixed-02-t1",
-        "question": "How many studies on the portal involve pediatric patients?",
+        "question": "How many datasets on the portal involve pediatric patients?",
         "expected_kb": "GRAPH",
         "persona": "FUNDER",
         "notes": "Requires querying the KG for patient age-related attributes."
@@ -169,7 +274,8 @@
   },
   {
     "session_id": "s-mixed-interleaved",
-    "description": "Mixed: alternating docs and graph turns within a single session",
+    "session_type": "MIXED",
+    "description": "Alternating docs and graph turns about NF model systems",
     "n_turns": 4,
     "turns": [
       {
@@ -181,17 +287,17 @@
       },
       {
         "id": "s-mixed-03-t2",
-        "question": "How many animal model tools are currently listed?",
+        "question": "How many mouse models are currently listed?",
         "expected_kb": "GRAPH",
         "persona": "REUSER",
         "notes": "Current count requires querying the KG."
       },
       {
         "id": "s-mixed-03-t3",
-        "question": "How do I request access to use restricted animal model data?",
+        "question": "How is info for these mouse models collected?",
         "expected_kb": "DOCS",
         "persona": "REUSER",
-        "notes": "Access request process is in documentation."
+        "notes": "Should be in documentation."
       },
       {
         "id": "s-mixed-03-t4",
@@ -204,36 +310,24 @@
   },
   {
     "session_id": "s-both-01",
-    "description": "BOTH: questions where either source is valid or both are needed",
-    "n_turns": 3,
+    "session_type": "BOTH",
+    "description": "Compound question requiring both sources",
+    "n_turns": 1,
     "turns": [
       {
         "id": "s-both-01-t1",
-        "question": "What NF1 data is available on the portal and how do I access it?",
+        "question": "Please walk me through how to download the largest available dataset",
         "expected_kb": "BOTH",
         "persona": "REUSER",
         "notes": "Compound question: 'what data' needs GRAPH; 'how to access' needs DOCS."
-      },
-      {
-        "id": "s-both-01-t2",
-        "question": "How do I find and download RNA-seq datasets for reanalysis?",
-        "expected_kb": "BOTH",
-        "persona": "REUSER",
-        "notes": "Navigation/process (DOCS) + finding actual records (GRAPH)."
-      },
-      {
-        "id": "s-both-01-t3",
-        "question": "What open access tools are available and what are the terms of use?",
-        "expected_kb": "BOTH",
-        "persona": "REUSER",
-        "notes": "Listing tools (GRAPH) + terms of use (DOCS)."
       }
     ]
   },
   {
     "session_id": "s-ambiguous-01",
-    "description": "Edge case: ambiguous queries that could reasonably route to either source",
-    "n_turns": 3,
+    "session_type": "BOTH",
+    "description": "Ambiguous queries that could reasonably route to either source",
+    "n_turns": 2,
     "turns": [
       {
         "id": "s-ambig-01-t1",
@@ -244,24 +338,18 @@
       },
       {
         "id": "s-ambig-01-t2",
-        "question": "What tools are available for NF research?",
-        "expected_kb": "BOTH",
-        "persona": "REUSER",
-        "notes": "Could use docs to explain tool categories or graph to list actual tools."
-      },
-      {
-        "id": "s-ambig-01-t3",
         "question": "Can I programmatically access the portal data?",
-        "expected_kb": "BOTH",
+        "expected_kb": "DOCS",
         "persona": "REUSER",
-        "notes": "API access info is in docs; actual data schema and endpoints involve both sources."
+        "notes": "API access info is in docs."
       }
     ]
   },
   {
     "session_id": "s-none-01",
-    "description": "NONE: off-topic or general requests that should not trigger any KB lookup",
-    "n_turns": 3,
+    "session_type": "NONE",
+    "description": "Off-topic or general requests that should not trigger any KB lookup",
+    "n_turns": 2,
     "turns": [
       {
         "id": "s-none-01-t1",
@@ -272,28 +360,22 @@
       },
       {
         "id": "s-none-01-t2",
-        "question": "What is neurofibromatosis?",
-        "expected_kb": "NONE",
-        "persona": "PATIENT",
-        "notes": "General medical/background question answerable from model knowledge; does not require querying the portal docs or KG."
-      },
-      {
-        "id": "s-none-01-t3",
-        "question": "Summarize the last message I sent you",
+        "question": "OK, can you submit a support ticket on my behalf?",
         "expected_kb": "NONE",
         "persona": "X",
-        "notes": "Meta-conversational request; no external KB source should be consulted."
+        "notes": "Requesting action assistant doesn't have"
       }
     ]
   },
   {
     "session_id": "s-funder-overview",
-    "description": "Mixed: funder asking for portfolio overview (graph) and governance details (docs)",
+    "session_type": "MIXED",
+    "description": "Funder asking for portfolio inventory counts and governance details",
     "n_turns": 4,
     "turns": [
       {
         "id": "s-funder-01-t1",
-        "question": "How many datasets are currently on the NF Data Portal?",
+        "question": "How many NTAP-funded datasets are currently on the NF Data Portal?",
         "expected_kb": "GRAPH",
         "persona": "FUNDER",
         "notes": "Current inventory counts require querying the KG."
@@ -307,14 +389,14 @@
       },
       {
         "id": "s-funder-01-t3",
-        "question": "How many active initiatives are tracked on the portal?",
+        "question": "I want to confirm the number of NTAP initiatives listed on the portal",
         "expected_kb": "GRAPH",
         "persona": "FUNDER",
         "notes": "Current initiative count from the KG."
       },
       {
         "id": "s-funder-01-t4",
-        "question": "What is the process for a new initiative to have its data hosted?",
+        "question": "What is the process for adding a new initiative?",
         "expected_kb": "DOCS",
         "persona": "FUNDER",
         "notes": "Onboarding process for new initiatives is in documentation."

--- a/benchmark/kb-routing/kb_routing_dataset.json
+++ b/benchmark/kb-routing/kb_routing_dataset.json
@@ -1,0 +1,324 @@
+[
+  {
+    "session_id": "s-docs-01",
+    "description": "DOCS-only: data contribution process for a new contributor",
+    "n_turns": 3,
+    "turns": [
+      {
+        "id": "s-docs-01-t1",
+        "question": "What are the steps to contribute data to the NF Data Portal?",
+        "expected_kb": "DOCS",
+        "persona": "CONTRIBUTOR",
+        "notes": "High-level contribution workflow; answer is entirely in help docs."
+      },
+      {
+        "id": "s-docs-01-t2",
+        "question": "What metadata fields are required when submitting files?",
+        "expected_kb": "DOCS",
+        "persona": "CONTRIBUTOR",
+        "notes": "Metadata requirements are documented; cannot be answered by querying the graph."
+      },
+      {
+        "id": "s-docs-01-t3",
+        "question": "What happens after my data passes quality control?",
+        "expected_kb": "DOCS",
+        "persona": "CONTRIBUTOR",
+        "notes": "Post-QC process (release, embargo lifting) is described in the help docs."
+      }
+    ]
+  },
+  {
+    "session_id": "s-docs-02",
+    "description": "DOCS-only: data access and licensing questions from a reuser",
+    "n_turns": 3,
+    "turns": [
+      {
+        "id": "s-docs-02-t1",
+        "question": "How do I get access to controlled access datasets on the NF portal?",
+        "expected_kb": "DOCS",
+        "persona": "REUSER",
+        "notes": "Access request process is described in documentation."
+      },
+      {
+        "id": "s-docs-02-t2",
+        "question": "What is the default license applied to non-human data submitted to the portal?",
+        "expected_kb": "DOCS",
+        "persona": "REUSER",
+        "notes": "License policy is in the docs; no need to query the graph."
+      },
+      {
+        "id": "s-docs-02-t3",
+        "question": "How should I cite the NF Data Portal in a publication?",
+        "expected_kb": "DOCS",
+        "persona": "REUSER",
+        "notes": "Citation guidance is a documentation topic."
+      }
+    ]
+  },
+  {
+    "session_id": "s-graph-01",
+    "description": "GRAPH-only: exploring available NF1 cell line tools",
+    "n_turns": 3,
+    "turns": [
+      {
+        "id": "s-graph-01-t1",
+        "question": "How many NF1 cell line tools are available in the portal?",
+        "expected_kb": "GRAPH",
+        "persona": "REUSER",
+        "notes": "Requires counting instances in the knowledge graph; docs won't have current counts."
+      },
+      {
+        "id": "s-graph-01-t2",
+        "question": "Show me NF1 cell lines derived from human donors",
+        "expected_kb": "GRAPH",
+        "persona": "REUSER",
+        "notes": "Filtering by donor type requires a SPARQL query over the KG."
+      },
+      {
+        "id": "s-graph-01-t3",
+        "question": "Which of those cell lines have loss-of-function NF1 mutations?",
+        "expected_kb": "GRAPH",
+        "persona": "REUSER",
+        "notes": "Follow-up filtering on mutation type; still a graph query. Uses conversation context."
+      }
+    ]
+  },
+  {
+    "session_id": "s-graph-02",
+    "description": "GRAPH-only: dataset discovery and publication search",
+    "n_turns": 3,
+    "turns": [
+      {
+        "id": "s-graph-02-t1",
+        "question": "How many studies on the portal are focused on schwannomatosis?",
+        "expected_kb": "GRAPH",
+        "persona": "FUNDER",
+        "notes": "Requires querying the graph for disease-specific study counts."
+      },
+      {
+        "id": "s-graph-02-t2",
+        "question": "What RNA-seq datasets are available for NF2 research?",
+        "expected_kb": "GRAPH",
+        "persona": "REUSER",
+        "notes": "Dataset listing by data type and disease; requires SPARQL over KG."
+      },
+      {
+        "id": "s-graph-02-t3",
+        "question": "Find publications about MPNST from the last five years",
+        "expected_kb": "GRAPH",
+        "persona": "REUSER",
+        "notes": "Publication search is a graph/text query task; docs won't list specific papers."
+      }
+    ]
+  },
+  {
+    "session_id": "s-mixed-docs-then-graph",
+    "description": "Mixed: contributor asks about process, then pivots to portal data inventory",
+    "n_turns": 3,
+    "turns": [
+      {
+        "id": "s-mixed-01-t1",
+        "question": "What is the data embargo policy for newly submitted datasets?",
+        "expected_kb": "DOCS",
+        "persona": "CONTRIBUTOR",
+        "notes": "Policy/process question; clearly a documentation lookup."
+      },
+      {
+        "id": "s-mixed-01-t2",
+        "question": "Now show me all the datasets that are currently publicly available",
+        "expected_kb": "GRAPH",
+        "persona": "REUSER",
+        "notes": "Pivot to actual data inventory; requires querying the KG."
+      },
+      {
+        "id": "s-mixed-01-t3",
+        "question": "How many of those are RNA-seq?",
+        "expected_kb": "GRAPH",
+        "persona": "REUSER",
+        "notes": "Follow-up count; still a graph query. Context-dependent turn."
+      }
+    ]
+  },
+  {
+    "session_id": "s-mixed-graph-then-docs",
+    "description": "Mixed: researcher explores data first, then asks how to contribute",
+    "n_turns": 3,
+    "turns": [
+      {
+        "id": "s-mixed-02-t1",
+        "question": "How many studies on the portal involve pediatric patients?",
+        "expected_kb": "GRAPH",
+        "persona": "FUNDER",
+        "notes": "Requires querying the KG for patient age-related attributes."
+      },
+      {
+        "id": "s-mixed-02-t2",
+        "question": "I'd like to add my pediatric NF1 study data to the portal. What do I need to prepare?",
+        "expected_kb": "DOCS",
+        "persona": "CONTRIBUTOR",
+        "notes": "Pivot to contribution guidance; clearly a documentation topic despite prior graph context."
+      },
+      {
+        "id": "s-mixed-02-t3",
+        "question": "What is the maximum file size for a single upload?",
+        "expected_kb": "DOCS",
+        "persona": "CONTRIBUTOR",
+        "notes": "Technical upload constraint is in documentation."
+      }
+    ]
+  },
+  {
+    "session_id": "s-mixed-interleaved",
+    "description": "Mixed: alternating docs and graph turns within a single session",
+    "n_turns": 4,
+    "turns": [
+      {
+        "id": "s-mixed-03-t1",
+        "question": "What types of NF model systems are supported by the portal?",
+        "expected_kb": "BOTH",
+        "persona": "REUSER",
+        "notes": "Docs describe supported resource categories; graph can enumerate actual types present. Either source gives a valid answer."
+      },
+      {
+        "id": "s-mixed-03-t2",
+        "question": "How many animal model tools are currently listed?",
+        "expected_kb": "GRAPH",
+        "persona": "REUSER",
+        "notes": "Current count requires querying the KG."
+      },
+      {
+        "id": "s-mixed-03-t3",
+        "question": "How do I request access to use restricted animal model data?",
+        "expected_kb": "DOCS",
+        "persona": "REUSER",
+        "notes": "Access request process is in documentation."
+      },
+      {
+        "id": "s-mixed-03-t4",
+        "question": "Find animal models with both NF1 and TP53 mutations",
+        "expected_kb": "GRAPH",
+        "persona": "REUSER",
+        "notes": "Filtering by co-occurring mutations requires SPARQL."
+      }
+    ]
+  },
+  {
+    "session_id": "s-both-01",
+    "description": "BOTH: questions where either source is valid or both are needed",
+    "n_turns": 3,
+    "turns": [
+      {
+        "id": "s-both-01-t1",
+        "question": "What NF1 data is available on the portal and how do I access it?",
+        "expected_kb": "BOTH",
+        "persona": "REUSER",
+        "notes": "Compound question: 'what data' needs GRAPH; 'how to access' needs DOCS."
+      },
+      {
+        "id": "s-both-01-t2",
+        "question": "How do I find and download RNA-seq datasets for reanalysis?",
+        "expected_kb": "BOTH",
+        "persona": "REUSER",
+        "notes": "Navigation/process (DOCS) + finding actual records (GRAPH)."
+      },
+      {
+        "id": "s-both-01-t3",
+        "question": "What open access tools are available and what are the terms of use?",
+        "expected_kb": "BOTH",
+        "persona": "REUSER",
+        "notes": "Listing tools (GRAPH) + terms of use (DOCS)."
+      }
+    ]
+  },
+  {
+    "session_id": "s-ambiguous-01",
+    "description": "Edge case: ambiguous queries that could reasonably route to either source",
+    "n_turns": 3,
+    "turns": [
+      {
+        "id": "s-ambig-01-t1",
+        "question": "Tell me about NF1 research on the portal",
+        "expected_kb": "BOTH",
+        "persona": "X",
+        "notes": "Vague overview question; agent might use docs for context or graph for data inventory. BOTH is acceptable."
+      },
+      {
+        "id": "s-ambig-01-t2",
+        "question": "What tools are available for NF research?",
+        "expected_kb": "BOTH",
+        "persona": "REUSER",
+        "notes": "Could use docs to explain tool categories or graph to list actual tools."
+      },
+      {
+        "id": "s-ambig-01-t3",
+        "question": "Can I programmatically access the portal data?",
+        "expected_kb": "BOTH",
+        "persona": "REUSER",
+        "notes": "API access info is in docs; actual data schema and endpoints involve both sources."
+      }
+    ]
+  },
+  {
+    "session_id": "s-none-01",
+    "description": "NONE: off-topic or general requests that should not trigger any KB lookup",
+    "n_turns": 3,
+    "turns": [
+      {
+        "id": "s-none-01-t1",
+        "question": "Help me write a Python script to reverse a string",
+        "expected_kb": "NONE",
+        "persona": "X",
+        "notes": "General programming question unrelated to the NF portal; no KB lookup needed."
+      },
+      {
+        "id": "s-none-01-t2",
+        "question": "What is neurofibromatosis?",
+        "expected_kb": "NONE",
+        "persona": "PATIENT",
+        "notes": "General medical/background question answerable from model knowledge; does not require querying the portal docs or KG."
+      },
+      {
+        "id": "s-none-01-t3",
+        "question": "Summarize the last message I sent you",
+        "expected_kb": "NONE",
+        "persona": "X",
+        "notes": "Meta-conversational request; no external KB source should be consulted."
+      }
+    ]
+  },
+  {
+    "session_id": "s-funder-overview",
+    "description": "Mixed: funder asking for portfolio overview (graph) and governance details (docs)",
+    "n_turns": 4,
+    "turns": [
+      {
+        "id": "s-funder-01-t1",
+        "question": "How many datasets are currently on the NF Data Portal?",
+        "expected_kb": "GRAPH",
+        "persona": "FUNDER",
+        "notes": "Current inventory counts require querying the KG."
+      },
+      {
+        "id": "s-funder-01-t2",
+        "question": "How is portal funding and governance described?",
+        "expected_kb": "DOCS",
+        "persona": "FUNDER",
+        "notes": "Funding and governance model is described in documentation."
+      },
+      {
+        "id": "s-funder-01-t3",
+        "question": "How many active initiatives are tracked on the portal?",
+        "expected_kb": "GRAPH",
+        "persona": "FUNDER",
+        "notes": "Current initiative count from the KG."
+      },
+      {
+        "id": "s-funder-01-t4",
+        "question": "What is the process for a new initiative to have its data hosted?",
+        "expected_kb": "DOCS",
+        "persona": "FUNDER",
+        "notes": "Onboarding process for new initiatives is in documentation."
+      }
+    ]
+  }
+]

--- a/benchmark/kb-routing/kb_routing_dataset.json
+++ b/benchmark/kb-routing/kb_routing_dataset.json
@@ -30,21 +30,6 @@
     ]
   },
   {
-    "session_id": "s-docs-single-03",
-    "session_type": "DOCS",
-    "description": "How to download data using the Synapse client",
-    "n_turns": 1,
-    "turns": [
-      {
-        "id": "s-docs-single-03-t1",
-        "question": "How do I download files from the NF portal using the Synapse Python client?",
-        "expected_kb": "DOCS",
-        "persona": "REUSER",
-        "notes": "Download instructions via the Synapse client are in the help docs."
-      }
-    ]
-  },
-  {
     "session_id": "s-graph-single-01",
     "session_type": "GRAPH",
     "description": "Count of biobanks on the portal",
@@ -145,24 +130,17 @@
     "session_id": "s-docs-02",
     "session_type": "DOCS",
     "description": "Data access and licensing questions from a reuser",
-    "n_turns": 3,
+    "n_turns": 2,
     "turns": [
       {
         "id": "s-docs-02-t1",
-        "question": "How do I get access to controlled access datasets on the NF portal?",
-        "expected_kb": "DOCS",
-        "persona": "REUSER",
-        "notes": "Access request process is described in documentation."
-      },
-      {
-        "id": "s-docs-02-t2",
         "question": "What is the default license applied to non-human data submitted to the portal?",
         "expected_kb": "DOCS",
         "persona": "REUSER",
         "notes": "License policy is in the docs; no need to query the graph."
       },
       {
-        "id": "s-docs-02-t3",
+        "id": "s-docs-02-t2",
         "question": "How should I cite the NF Data Portal in a publication?",
         "expected_kb": "DOCS",
         "persona": "REUSER",
@@ -316,10 +294,10 @@
     "turns": [
       {
         "id": "s-both-01-t1",
-        "question": "Please walk me through how to download the largest available dataset",
+        "question": "What's the largest available dataset? Is there an applicable guide that walks me through how to download it?",
         "expected_kb": "BOTH",
         "persona": "REUSER",
-        "notes": "Compound question: 'what data' needs GRAPH; 'how to access' needs DOCS."
+        "notes": "Two-part question: identifying the largest dataset requires GRAPH; the download guide is in DOCS."
       }
     ]
   },
@@ -338,10 +316,10 @@
       },
       {
         "id": "s-ambig-01-t2",
-        "question": "Can I programmatically access the portal data?",
+        "question": "Which clients are available for programmatic access?",
         "expected_kb": "DOCS",
         "persona": "REUSER",
-        "notes": "API access info is in docs."
+        "notes": "Available clients (e.g. Synapse Python/R clients) are described in the docs."
       }
     ]
   },
@@ -382,24 +360,24 @@
       },
       {
         "id": "s-funder-01-t2",
-        "question": "How is portal funding and governance described?",
-        "expected_kb": "DOCS",
+        "question": "I'm trying to get a complete picture of which funders have contributed datasets aside from the historical main funders",
+        "expected_kb": "BOTH",
         "persona": "FUNDER",
-        "notes": "Funding and governance model is described in documentation."
+        "notes": "Intentionally open-ended. A well-routing agent should consult the docs for named major funders/initiatives and the KG to enumerate all funder entities directly on dataset entities. Neither source alone gives the complete picture."
       },
       {
         "id": "s-funder-01-t3",
-        "question": "I want to confirm the number of NTAP initiatives listed on the portal",
+        "question": "Which funder has the most initiatives?",
         "expected_kb": "GRAPH",
         "persona": "FUNDER",
-        "notes": "Current initiative count from the KG."
+        "notes": "Ranking funders by initiative count requires aggregating over the KG."
       },
       {
         "id": "s-funder-01-t4",
-        "question": "What is the process for adding a new initiative?",
+        "question": "Who should I contact to provide potential support for the portal?",
         "expected_kb": "DOCS",
         "persona": "FUNDER",
-        "notes": "Onboarding process for new initiatives is in documentation."
+        "notes": "Contact information for portal support/partnerships is in the docs; no KG lookup needed."
       }
     ]
   }

--- a/benchmark/kb-routing/kb_routing_dataset.json
+++ b/benchmark/kb-routing/kb_routing_dataset.json
@@ -47,15 +47,15 @@
   {
     "session_id": "s-graph-single-02",
     "session_type": "GRAPH",
-    "description": "Animal model tools for NF2",
+    "description": "Count of animal model tools",
     "n_turns": 1,
     "turns": [
       {
         "id": "s-graph-single-02-t1",
-        "question": "List the animal model tools available for NF2 research",
+        "question": "How many animal model tools are on the portal?",
         "expected_kb": "GRAPH",
         "persona": "REUSER",
-        "notes": "Listing specific resources requires a SPARQL query over the KG."
+        "notes": "Current count requires querying the KG."
       }
     ]
   },
@@ -128,8 +128,8 @@
   },
   {
     "session_id": "s-docs-02",
-    "session_type": "DOCS",
-    "description": "Data access and licensing questions from a reuser",
+    "session_type": "MIXED",
+    "description": "Licensing policy from docs, then actual license distribution from graph",
     "n_turns": 2,
     "turns": [
       {
@@ -141,10 +141,10 @@
       },
       {
         "id": "s-docs-02-t2",
-        "question": "How should I cite the NF Data Portal in a publication?",
-        "expected_kb": "DOCS",
+        "question": "What's the most common dataset license?",
+        "expected_kb": "GRAPH",
         "persona": "REUSER",
-        "notes": "Citation guidance is a documentation topic."
+        "notes": "Requires aggregating license values across dataset entities in the KG; docs only describe the default policy, not actual distribution."
       }
     ]
   },

--- a/benchmark/kb-routing/kb_routing_schema.json
+++ b/benchmark/kb-routing/kb_routing_schema.json
@@ -5,16 +5,21 @@
   "type": "array",
   "items": {
     "type": "object",
-    "required": ["session_id", "description", "n_turns", "turns"],
+    "required": ["session_id", "session_type", "description", "n_turns", "turns"],
     "additionalProperties": false,
     "properties": {
       "session_id": {
         "type": "string",
         "description": "Unique identifier for the session."
       },
+      "session_type": {
+        "type": "string",
+        "enum": ["DOCS", "GRAPH", "MIXED", "BOTH", "NONE"],
+        "description": "Routing pattern for the session. DOCS = all turns expect docs KB; GRAPH = all turns expect KG; MIXED = turns route to different sources; BOTH = all turns accept either/both sources; NONE = no KB lookup expected for any turn."
+      },
       "description": {
         "type": "string",
-        "description": "Human-readable description of the session's intent and expected routing pattern."
+        "description": "Human-readable description of the session's intent and content."
       },
       "n_turns": {
         "type": "integer",

--- a/benchmark/kb-routing/kb_routing_schema.json
+++ b/benchmark/kb-routing/kb_routing_schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "KB Routing Sessions Dataset",
+  "description": "Multi-turn sessions for evaluating KB source selection in a multi-source agent.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["session_id", "description", "n_turns", "turns"],
+    "additionalProperties": false,
+    "properties": {
+      "session_id": {
+        "type": "string",
+        "description": "Unique identifier for the session."
+      },
+      "description": {
+        "type": "string",
+        "description": "Human-readable description of the session's intent and expected routing pattern."
+      },
+      "n_turns": {
+        "type": "integer",
+        "minimum": 1,
+        "description": "Number of turns in this session. Must equal the length of the turns array."
+      },
+      "turns": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "required": ["id", "question", "expected_kb", "persona"],
+          "additionalProperties": false,
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Unique turn identifier (UUID or slug)."
+            },
+            "question": {
+              "type": "string",
+              "description": "The user's question as it would appear in the chat."
+            },
+            "expected_kb": {
+              "type": "string",
+              "enum": ["DOCS", "GRAPH", "BOTH", "NONE"],
+              "description": "Which KB source(s) the agent should use. DOCS = documentation KB; GRAPH = KG action groups (SPARQL); BOTH = either is acceptable or both should be used; NONE = no KB lookup expected (agent should answer from general knowledge or decline)."
+            },
+            "persona": {
+              "type": "string",
+              "enum": ["CONTRIBUTOR", "REUSER", "FUNDER", "PATIENT", "X"],
+              "description": "User persona for the question."
+            },
+            "notes": {
+              "type": "string",
+              "description": "Optional reasoning for why this question maps to the expected KB source, or edge-case notes."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/benchmark/kb-routing/update_readme_stats.py
+++ b/benchmark/kb-routing/update_readme_stats.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Update the 'Seed dataset composition' table in README.md from kb_routing_dataset.json.
+
+Run after any changes to the dataset:
+    python update_readme_stats.py
+"""
+
+import json
+import re
+from pathlib import Path
+
+DATASET = Path("kb_routing_dataset.json")
+README = Path("README.md")
+
+SESSION_TYPES = ["DOCS", "GRAPH", "MIXED", "BOTH", "NONE"]
+
+TABLE_RE = re.compile(
+    r"(### Dataset composition\n\n)"   # heading preserved
+    r"\|.*?\n"                               # header row
+    r"\|[-| ]+\n"                            # separator row
+    r"(?:\|.*?\n)+"                          # data rows (one or more)
+    r"(\|.*?\n)",                            # total row (last row)
+    re.DOTALL,
+)
+
+
+def compute_stats(data: list[dict]) -> dict:
+    stats = {t: {"sessions": 0, "single": 0, "multi": 0, "turns": 0} for t in SESSION_TYPES}
+    for session in data:
+        t = session["session_type"]
+        n = session["n_turns"]
+        stats[t]["sessions"] += 1
+        stats[t]["turns"] += n
+        if n == 1:
+            stats[t]["single"] += 1
+        else:
+            stats[t]["multi"] += 1
+    return stats
+
+
+def build_table(stats: dict) -> str:
+    total_sessions = sum(v["sessions"] for v in stats.values())
+    total_single = sum(v["single"] for v in stats.values())
+    total_multi = sum(v["multi"] for v in stats.values())
+    total_turns = sum(v["turns"] for v in stats.values())
+
+    lines = [
+        "| `session_type` | Sessions | Single-turn | Multi-turn | Turns |",
+        "|----------------|----------|-------------|------------|-------|",
+    ]
+    for t in SESSION_TYPES:
+        v = stats[t]
+        single = str(v["single"]) if v["single"] else "—"
+        multi = str(v["multi"]) if v["multi"] else "—"
+        lines.append(f"| {t} | {v['sessions']} | {single} | {multi} | {v['turns']} |")
+    lines.append(
+        f"| **Total** | **{total_sessions}** | **{total_single}** | **{total_multi}** | **{total_turns}** |"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def update_readme(stats: dict) -> None:
+    readme = README.read_text()
+    new_table = build_table(stats)
+
+    # Replace everything between the heading and the next --- separator
+    section_re = re.compile(
+        r"(### Dataset composition\n\n)"
+        r"(\|[^\n]*\n\|[-| ]+\n(?:\|[^\n]*\n)+)",
+    )
+    match = section_re.search(readme)
+    if not match:
+        raise RuntimeError("Could not find 'Seed dataset composition' table in README.md")
+
+    updated = readme[: match.start(2)] + new_table + readme[match.end(2) :]
+    README.write_text(updated)
+    print(f"README.md updated.")
+
+
+def main() -> None:
+    data = json.loads(DATASET.read_text())
+    stats = compute_stats(data)
+
+    print(f"{'Type':<8} {'Sessions':>8} {'Single':>8} {'Multi':>8} {'Turns':>8}")
+    print("-" * 44)
+    for t in SESSION_TYPES:
+        v = stats[t]
+        print(f"{t:<8} {v['sessions']:>8} {v['single']:>8} {v['multi']:>8} {v['turns']:>8}")
+    totals = (
+        sum(v["sessions"] for v in stats.values()),
+        sum(v["single"] for v in stats.values()),
+        sum(v["multi"] for v in stats.values()),
+        sum(v["turns"] for v in stats.values()),
+    )
+    print("-" * 44)
+    print(f"{'Total':<8} {totals[0]:>8} {totals[1]:>8} {totals[2]:>8} {totals[3]:>8}")
+
+    update_readme(stats)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a new `benchmark/kb-routing/` eval that measures KB source routing accuracy for the multi-source agent — whether it correctly selects the docs knowledge base, the SPARQL knowledge graph, both, or neither for each query. Source is detected from Bedrock trace events. Dataset has been created and carefully curated with a seed set of 18 mixed-turns sessions with explicit `expected_kb` and `session_type` labels, an evaluation script with efficiency-aware scoring, and a stats script that keeps the docs in sync.                